### PR TITLE
fix: 修复图表编辑页面通过浏览器后退按钮返回视图混乱的问题

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/pages/Dashboard/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/Dashboard/index.tsx
@@ -35,6 +35,7 @@ import { makeSelectBoardConfigById } from '../../slice/selector';
 import { fetchBoardDetail } from '../../slice/thunk';
 import { BoardState, VizRenderMode } from '../../slice/types';
 import BoardEditor from '../BoardEditor';
+import { editDashBoardInfoActions } from '../BoardEditor/slice';
 import AutoBoardCore from './AutoDashboard/AutoBoardCore';
 import FreeBoardCore from './FreeDashboard/FreeBoardCore';
 export interface DashboardProps {
@@ -74,6 +75,10 @@ export const Dashboard: React.FC<DashboardProps> = memo(
         ? urlSearchTransfer.toParams(filterSearchUrl)
         : undefined;
     }, [filterSearchUrl]);
+
+    useEffect(() => {
+      dispatch(editDashBoardInfoActions.changeChartEditorProps(undefined));
+    }, [dispatch]);
 
     useEffect(() => {
       if (boardId && fetchData) {


### PR DESCRIPTION
问题：
图表编辑页通过浏览器按钮后退到首页，再次点击编辑按钮，展示的不是预期之中的dashboard编辑页
![动画 (3)](https://user-images.githubusercontent.com/35984031/139030008-ca03bcfc-aa50-4f76-b647-beccb1746124.gif)

出现原因：
该区域模块没有通过路由渲染(在代码逻辑中发现了注释掉的push函数)，而是通过变量控制模块加载，浏览器按钮操作并不会清除对应的props

解决方案：
在视图预览界面清除对应props