### PR TITLE
fix: chartPlugin is not loaded for first time

### DIFF
--- a/frontend/src/app/pages/ChartWorkbenchPage/models/ChartManager.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/models/ChartManager.ts
@@ -50,6 +50,7 @@ const {
 class ChartManager {
   private _loader = new ChartTools.ChartPluginLoader();
   private _isLoaded = false;
+  private _isChartPluginLoaded = false;
   private _charts: Chart[] = this._basicCharts();
   private static _manager: ChartManager | null = null;
 
@@ -61,11 +62,22 @@ class ChartManager {
   }
 
   public async load() {
-    if (this._isLoaded) {
+    if (this._isLoaded && this._isChartPluginLoaded) {
       return;
     }
-    const pluginsPaths = await getChartPluginPaths();
+    let pluginsPaths: string[] = [];
+    try {
+      pluginsPaths = await getChartPluginPaths();
+      this._isChartPluginLoaded = true;
+      this._isLoaded = false;
+    } catch (error) {
+      console.log(error);
+    }
     return await this._loadCustomizeCharts(pluginsPaths);
+  }
+
+  public getChartPluginLoadedStatus() {
+    return this._isChartPluginLoaded;
   }
 
   public getAllChartMetas(): ChartMetadata[] {

--- a/frontend/src/app/pages/MainPage/slice/thunks.ts
+++ b/frontend/src/app/pages/MainPage/slice/thunks.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import ChartManager from 'app/pages/ChartWorkbenchPage/models/ChartManager';
 import { selectLoggedInUser } from 'app/slice/selectors';
 import { RootState } from 'types';
 import { request } from 'utils/request';
@@ -32,6 +33,10 @@ export const getUserSettings = createAsyncThunk<
   string | undefined
 >('main/getUserSettings', async orgId => {
   try {
+    const chartManager = ChartManager.instance();
+    if (chartManager.getChartPluginLoadedStatus() === false) {
+      await chartManager.load();
+    }
     const [{ data: userSettings }, { data: organizations }] = await Promise.all(
       [
         request<UserSetting[]>('settings/user'),


### PR DESCRIPTION
问题：
页面首次打开，输入账号密码，进入仪表盘，自定义扩展图表加载失败。
原因：
chart控制器只有第一次加载才会执行load函数，未登录状态load函数中的请求发送失败，且登录之后并未重新请求。
解决方法：
重新梳理load函数，在登录完成之后的user相关函数中插入有关ChartPlugin的判断