### PR TITLE
Startup script compatible with MacOS

### DIFF
--- a/bin/datart-server.sh
+++ b/bin/datart-server.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BASE_DIR=$(dirname $(dirname $(readlink -f "$0")))
+BASE_DIR=$(cd "$(dirname "$0")/.."; pwd -P)
 
 echo "working dir ${BASE_DIR}"
 


### PR DESCRIPTION
`readlink -f` does not exist on MacOS, So change the method of getting absolute path to be compatible with macos。

In addition, the conversion line of the `data-server.sh`  in the provided installation zip file is in windows format( with CRLF line terminators) , so the script CANNOT be run on Unix or Linux .