### PR TITLE
Feature jump for http url

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -146,10 +146,10 @@ module.exports = {
     hot: true,
     proxy: {
       '/api/v1': {
-        target: 'http://localhost:8080/',
+        target: 'http://192.168.50.29:8083/',
       },
       '/resources': {
-        target: 'http://localhost:8080/',
+        target: 'http://192.168.50.29:8083/',
       },
     },
     historyApiFallback: {

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const CracoLessPlugin = require('craco-less');
 const WebpackBar = require('webpackbar');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+// const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const {
   when,
   whenDev,
@@ -56,7 +57,11 @@ module.exports = {
   ],
   webpack: {
     alias: {},
-    plugins: [new WebpackBar(), new MonacoWebpackPlugin({ languages: [''] })],
+    plugins: [
+      new WebpackBar(),
+      new MonacoWebpackPlugin({ languages: [''] }),
+      // new BundleAnalyzerPlugin(),
+    ],
     configure: (webpackConfig, { env, paths }) => {
       // paths.appPath='public'
       // paths.appBuild = 'dist'; // 配合输出打包修改文件目录
@@ -146,10 +151,10 @@ module.exports = {
     hot: true,
     proxy: {
       '/api/v1': {
-        target: 'http://192.168.50.29:8083/',
+        target: 'http://localhost:8080/',
       },
       '/resources': {
-        target: 'http://192.168.50.29:8083/',
+        target: 'http://localhost:8080/',
       },
     },
     historyApiFallback: {

--- a/frontend/src/app/pages/DashBoardPage/components/WidgetProvider/WidgetMethodProvider.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/WidgetProvider/WidgetMethodProvider.tsx
@@ -299,10 +299,12 @@ export const WidgetMethodProvider: FC<{ widgetId: string }> = ({
     (values: { widget: Widget; params: ChartMouseEventParams }) => {
       const { widget, params } = values;
       const jumpConfig = widget.config?.jumpConfig;
+      const targetType = jumpConfig?.targetType || 1;
+      const httpUrl = jumpConfig?.httpUrl || '';
+      const queryName = jumpConfig?.queryName || '';
       const targetId = jumpConfig?.target?.relId;
       const jumpFieldName: string = jumpConfig?.field?.jumpFieldName || '';
-
-      if (typeof jumpConfig?.filter === 'object') {
+      if (typeof jumpConfig?.filter === 'object' && targetType === 1) {
         const searchParamsStr = urlSearchTransfer.toUrlString({
           [jumpConfig?.filter?.filterId]:
             (params?.data?.rowData?.[jumpFieldName] as string) || '',
@@ -312,6 +314,14 @@ export const WidgetMethodProvider: FC<{ widgetId: string }> = ({
             `/organizations/${orgId}/vizs/${targetId}?${searchParamsStr}`,
           );
         }
+      } else if (targetType === 2) {
+        let url;
+        if (httpUrl.indexOf('?') > -1) {
+          url = `${httpUrl}&${queryName}=${params?.data?.rowData?.[jumpFieldName]}`;
+        } else {
+          url = `${httpUrl}?${queryName}=${params?.data?.rowData?.[jumpFieldName]}`;
+        }
+        window.location.href = url;
       }
     },
     [history, orgId],

--- a/frontend/src/app/pages/DashBoardPage/pages/Board/slice/types.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/Board/slice/types.ts
@@ -161,6 +161,9 @@ export interface JumpConfigField {
 }
 export interface JumpConfig {
   open: boolean;
+  targetType: number;
+  httpUrl: string;
+  queryName: string;
   field: JumpConfigField;
   target: JumpConfigTarget;
   filter: JumpConfigFilter;

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
@@ -191,16 +191,16 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
           <Form.Item
             label="HTTP URL"
             name="httpUrl"
-            rules={[{ required: true, message: '跳转目标HTTP URL' }]}
+            rules={[{ required: true, message: '跳转目标HTTP URL不能为空' }]}
           >
             <Input placeholder="jump http url" />
           </Form.Item>
         )}
         {targetType === 2 && (
           <Form.Item
-            label="Query Name"
+            label="URL参数"
             name="queryName"
-            rules={[{ required: true, message: '查询参数名称' }]}
+            rules={[{ required: true, message: 'URL参数名称不能为空' }]}
           >
             <Input placeholder="query param name" />
           </Form.Item>

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
@@ -151,6 +151,15 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
     >
       <Form {...formItemLayout} form={form} onFinish={onFinish}>
         <Form.Item
+          label="跳转类型"
+          name="target"
+          rules={[{ required: true, message: '跳转类型不能为空' }]}
+        >
+          <SelectJumpFields
+            chartGroupColumns={chartGroupColumns}
+          ></SelectJumpFields>
+        </Form.Item>
+        <Form.Item
           label="跳转目标"
           name="target"
           rules={[{ required: true, message: '跳转目标不能为空' }]}

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/SettingJumpModal/index.tsx
@@ -4,7 +4,7 @@ import {
   FolderOpenFilled,
   FundFilled,
 } from '@ant-design/icons';
-import { Form, Modal, ModalProps } from 'antd';
+import { Form, Input, Modal, ModalProps, Select } from 'antd';
 import { BoardContext } from 'app/pages/DashBoardPage/contexts/BoardContext';
 import { selectDataChartById } from 'app/pages/DashBoardPage/pages/Board/slice/selector';
 import { BoardState } from 'app/pages/DashBoardPage/pages/Board/slice/types';
@@ -33,6 +33,7 @@ const formItemLayout = {
   labelCol: { span: 6 },
   wrapperCol: { span: 18 },
 };
+const { Option } = Select;
 interface SettingJumpModalProps extends ModalProps {}
 export const SettingJumpModal: FC<SettingJumpModalProps> = ({
   children,
@@ -88,8 +89,11 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
   useEffect(() => {
     const _jumpConfig = curJumpWidget?.config?.jumpConfig;
     setVisible(jumpVisible);
+    setTargetType(_jumpConfig?.targetType || 1);
     if (jumpVisible && _jumpConfig) {
-      onGetController(curJumpWidget?.config?.jumpConfig?.target);
+      if (curJumpWidget?.config?.jumpConfig?.targetType === 1) {
+        onGetController(curJumpWidget?.config?.jumpConfig?.target);
+      }
       form.setFieldsValue(_jumpConfig);
     }
   }, [jumpVisible, curJumpWidget, form, onGetController]);
@@ -99,6 +103,7 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
   const dataChart = useSelector((state: { board: BoardState }) =>
     selectDataChartById(state, curJumpWidget?.datachartId),
   );
+  const [targetType, setTargetType] = useState(1);
   const chartGroupColumns = useMemo(() => {
     if (!dataChart) {
       return [];
@@ -109,6 +114,14 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
   }, [dataChart]);
   const onTargetChange = useCallback(
     value => {
+      form.setFieldsValue({ filter: undefined });
+      onGetController(value);
+    },
+    [form, onGetController],
+  );
+  const onTargetTypeChange = useCallback(
+    value => {
+      setTargetType(value);
       form.setFieldsValue({ filter: undefined });
       onGetController(value);
     },
@@ -152,24 +165,46 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
       <Form {...formItemLayout} form={form} onFinish={onFinish}>
         <Form.Item
           label="跳转类型"
-          name="target"
+          name="targetType"
           rules={[{ required: true, message: '跳转类型不能为空' }]}
         >
-          <SelectJumpFields
-            chartGroupColumns={chartGroupColumns}
-          ></SelectJumpFields>
+          <Select defaultValue={1} onChange={onTargetTypeChange}>
+            <Option value={1}>仪表盘&amp;数据图表</Option>
+            <Option value={2}>HTTP URL</Option>
+          </Select>
         </Form.Item>
-        <Form.Item
-          label="跳转目标"
-          name="target"
-          rules={[{ required: true, message: '跳转目标不能为空' }]}
-        >
-          <TargetTreeSelect
-            filterBoardId={boardId}
-            treeData={treeData}
-            onChange={onTargetChange}
-          />
-        </Form.Item>
+        {targetType === 1 && (
+          <Form.Item
+            label="跳转目标"
+            name="target"
+            rules={[{ required: true, message: '跳转目标不能为空' }]}
+          >
+            <TargetTreeSelect
+              filterBoardId={boardId}
+              treeData={treeData}
+              onChange={onTargetChange}
+            />
+          </Form.Item>
+        )}
+
+        {targetType === 2 && (
+          <Form.Item
+            label="HTTP URL"
+            name="httpUrl"
+            rules={[{ required: true, message: '跳转目标HTTP URL' }]}
+          >
+            <Input placeholder="jump http url" />
+          </Form.Item>
+        )}
+        {targetType === 2 && (
+          <Form.Item
+            label="Query Name"
+            name="queryName"
+            rules={[{ required: true, message: '查询参数名称' }]}
+          >
+            <Input placeholder="query param name" />
+          </Form.Item>
+        )}
         {chartGroupColumns?.length > 1 && (
           <Form.Item
             label="关联字段"
@@ -181,18 +216,19 @@ export const SettingJumpModal: FC<SettingJumpModalProps> = ({
             ></SelectJumpFields>
           </Form.Item>
         )}
-
-        <Form.Item
-          label="关联筛选"
-          name="filter"
-          rules={[{ required: true, message: '关联筛选不能为空' }]}
-        >
-          <FilterSelect
-            loading={controllerLoading}
-            options={controllers}
-            placeholder="请选择关联筛选"
-          />
-        </Form.Item>
+        {targetType === 1 && (
+          <Form.Item
+            label="关联筛选"
+            name="filter"
+            rules={[{ required: true, message: '关联筛选不能为空' }]}
+          >
+            <FilterSelect
+              loading={controllerLoading}
+              options={controllers}
+              placeholder="请选择关联筛选"
+            />
+          </Form.Item>
+        )}
       </Form>
     </Modal>
   );


### PR DESCRIPTION
- 配置跳转，支持配置 URL
![image](https://user-images.githubusercontent.com/15976650/144737797-b87995a8-e237-44d7-bb1a-38d3c4c66ba1.png)
![image](https://user-images.githubusercontent.com/15976650/144737888-ad92e655-931c-4e52-be20-ed2757ea9631.png)

- HTTP URL 支持相对地址和绝对地址。如果datart 分享出去的链接，建议配置相对地址。防止服务器迁移后无法使用
- 这样可以解决曲线先解决一下分享出去无法跳转的问题。原有跳转方式保留

本人非 React专业方向 ，代码可能比较粗糙，如有问题，请官方优化一下，哈哈