### PR TITLE
feat: table add condition style. issue #259

### DIFF
--- a/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/add.tsx
+++ b/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/add.tsx
@@ -1,0 +1,292 @@
+import { Col, Form, Input, InputNumber, Modal, Radio, Row, Select } from 'antd';
+import { ColorPickerPopover } from 'app/components/ReactColorPicker';
+import { ColumnTypes } from 'app/pages/MainPage/pages/ViewPage/constants';
+import React, { memo, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ConditionStyleFormValues } from '.';
+import {
+  ConditionOperatorTypes,
+  ConditionStyleRange,
+  OperatorTypes,
+  OperatorTypesLocale,
+} from './type';
+
+interface AddProps {
+  currentSelectedItem?: any;
+  translate?: (title: string, options?: any) => string;
+  visible: boolean;
+  values: ConditionStyleFormValues;
+  onOk: (values: ConditionStyleFormValues) => void;
+  onCancel: () => void;
+}
+
+export default function Add({
+  translate: t = title => title,
+  values,
+  visible,
+  onOk,
+  onCancel,
+  currentSelectedItem: { label, type },
+}: AddProps) {
+  const [colors] = useState([
+    {
+      name: 'background',
+      label: t('conditionStyleTable.header.color.background'),
+      value: undefined,
+    },
+    {
+      name: 'text',
+      label: t('conditionStyleTable.header.color.text'),
+      value: undefined,
+    },
+  ]);
+  const [operatorSelect, setOperatorSelect] = useState<
+    { label: string; value: string }[]
+  >([]);
+  const [operatorValue, setOperatorValue] = useState<OperatorTypes>(
+    OperatorTypes.Equal,
+  );
+  const [form] = Form.useForm<ConditionStyleFormValues>();
+
+  useEffect(() => {
+    if (type) {
+      setOperatorSelect(
+        ConditionOperatorTypes[type]?.map(item => ({
+          label: `${OperatorTypesLocale[item]} [${item}]`,
+          value: item,
+        })),
+      );
+    } else {
+      setOperatorSelect([]);
+    }
+  }, [type]);
+
+  useEffect(() => {
+    // !重置form
+    if (visible) {
+      const result: Partial<ConditionStyleFormValues> =
+        Object.keys(values).length === 0
+          ? {
+              range: ConditionStyleRange.Cell,
+              operator: OperatorTypes.Equal,
+            }
+          : values;
+
+      form.setFieldsValue(result);
+      setOperatorValue(result.operator ?? OperatorTypes.Equal);
+    }
+  }, [form, visible, values, label]);
+
+  const modalOk = () => {
+    form.validateFields().then(values => {
+      onOk({
+        ...values,
+        target: {
+          name: label,
+          type,
+        },
+      });
+    });
+  };
+
+  const operatorChange = (value: OperatorTypes) => {
+    setOperatorValue(value);
+  };
+
+  const renderValueNode = () => {
+    let DefaultNode = <></>;
+    switch (type) {
+      case ColumnTypes.Number:
+        DefaultNode = <InputNumber />;
+        break;
+      default:
+        DefaultNode = <Input />;
+        break;
+    }
+
+    switch (operatorValue) {
+      case OperatorTypes.In:
+      case OperatorTypes.NotIn:
+        return (
+          <Select
+            mode="tags"
+            notFoundContent={<>可添加多个值(输入内容后按下回车键完成添加)</>}
+          />
+        );
+      case OperatorTypes.Between:
+        return <InputNumberScope />;
+      default:
+        return DefaultNode;
+    }
+  };
+
+  return (
+    <Modal
+      destroyOnClose
+      title="条件格式"
+      visible={visible}
+      onOk={modalOk}
+      onCancel={onCancel}
+    >
+      <Form
+        name="condition-style-form"
+        labelAlign="left"
+        labelCol={{ span: 8 }}
+        wrapperCol={{ span: 16 }}
+        preserve={false}
+        form={form}
+        autoComplete="off"
+      >
+        <Form.Item label="uid" name="uid" hidden>
+          <Input />
+        </Form.Item>
+
+        <Form.Item
+          label={t('conditionStyleTable.header.range.title')}
+          name="range"
+          rules={[{ required: true }]}
+        >
+          <Radio.Group>
+            <Radio.Button value="cell">
+              {t('conditionStyleTable.header.range.cell')}
+            </Radio.Button>
+            <Radio.Button value="row">
+              {t('conditionStyleTable.header.range.row')}
+            </Radio.Button>
+          </Radio.Group>
+        </Form.Item>
+
+        <Form.Item
+          label={t('conditionStyleTable.header.operator')}
+          name="operator"
+          rules={[{ required: true }]}
+        >
+          <Select options={operatorSelect} onChange={operatorChange} />
+        </Form.Item>
+
+        {operatorValue !== OperatorTypes.IsNull ? (
+          <Form.Item
+            label={t('conditionStyleTable.header.value')}
+            name="value"
+            rules={[{ required: true }]}
+          >
+            {renderValueNode()}
+          </Form.Item>
+        ) : null}
+
+        <Form.Item label={t('conditionStyleTable.header.color.title')}>
+          <Row gutter={24} align="middle">
+            {colors.map(({ label, value, name }) => (
+              <Form.Item key={label} name={['color', name]} noStyle>
+                <ColorSelector label={label} value={value} />
+              </Form.Item>
+            ))}
+          </Row>
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}
+
+const ColorSelector = memo(
+  ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value?: string;
+    onChange?: (value: any) => void;
+  }) => {
+    return (
+      <>
+        <Col>{label}</Col>
+        <Col>
+          <ColorPickerPopover defaultValue={value} onSubmit={onChange}>
+            <StyledColor color={value} />
+          </ColorPickerPopover>
+        </Col>
+      </>
+    );
+  },
+);
+
+const InputNumberScope = memo(
+  ({
+    value,
+    onChange,
+  }: {
+    value?: [number, number];
+    onChange?: (value: any) => void;
+  }) => {
+    const [[min, max], setState] = useState<
+      [number | undefined, number | undefined]
+    >([undefined, undefined]);
+    const [index, setIndex] = useState<number>(0);
+
+    useEffect(() => {
+      setIndex(index + 1);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      if (Array.isArray(value)) {
+        setState([Number(value[0]), Number(value[1])]);
+      } else {
+        setState([value, undefined]);
+      }
+    }, [value]);
+
+    const inputNumberScopeChange = state => {
+      setState(state);
+      console.log(state);
+      const result = state.filter(num => typeof num === 'number');
+      if (result.length === 2) {
+        onChange?.(state);
+      } else {
+        onChange?.(undefined);
+      }
+    };
+
+    const minChange = (value: number) => inputNumberScopeChange([value, max]);
+    const maxChange = (value: number) => inputNumberScopeChange([min, value]);
+
+    return (
+      <Row gutter={24} align="middle" key={index}>
+        <Col>
+          <InputNumber
+            placeholder="最小值"
+            defaultValue={min}
+            onChange={minChange}
+          />
+        </Col>
+        <Col>-</Col>
+        <Col>
+          <InputNumber
+            placeholder="最大值"
+            defaultValue={max}
+            onChange={maxChange}
+          />
+        </Col>
+      </Row>
+    );
+  },
+);
+
+const StyledColor = styled.div`
+  width: 16px;
+  height: 16px;
+  background-color: ${props => props.color};
+  position: relative;
+  ::after {
+    position: absolute;
+    top: -7px;
+    left: -7px;
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    border-radius: 5px;
+    border: 1px solid #d9d9d9;
+    content: '';
+  }
+`;

--- a/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/index.tsx
+++ b/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/index.tsx
@@ -1,0 +1,198 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Col, Popconfirm, Row, Space, Table, Tag } from 'antd';
+import { ColumnsType } from 'antd/lib/table';
+import { ChartStyleSectionConfig } from 'app/types/ChartConfig';
+import { cloneDeep } from 'lodash';
+import { FC, memo, useState } from 'react';
+import styled from 'styled-components';
+import { CloneValueDeep } from 'utils/object';
+import { v4 as uuidv4 } from 'uuid';
+import { ItemLayoutProps } from '../../types';
+import { itemLayoutComparer } from '../../utils';
+import AddModal from './add';
+import { ConditionStyleRange, OperatorTypes } from './type';
+
+export interface ConditionStyleFormValues {
+  uid: string;
+  target: { name: string; type: any };
+  range: ConditionStyleRange;
+  operator: OperatorTypes;
+  value: string;
+  color: { background: string; text: string };
+}
+
+const ConditionStylePanel: FC<ItemLayoutProps<ChartStyleSectionConfig>> = memo(
+  ({
+    ancestors,
+    translate: t = title => title,
+    data,
+    onChange,
+    dataConfigs,
+    currentSelectedItem,
+  }) => {
+    const [myData] = useState(CloneValueDeep(data));
+    const [visible, setVisible] = useState<boolean>(false);
+    const [dataSource, setDataSource] = useState<ConditionStyleFormValues[]>(
+      myData.value || [],
+    );
+    const [currentItem, setCurrentItem] = useState<ConditionStyleFormValues>(
+      {} as ConditionStyleFormValues,
+    );
+
+    const onEditItem = (values: ConditionStyleFormValues) => {
+      setCurrentItem(cloneDeep(values));
+      openConditionStyle();
+    };
+    const onRemoveItem = (values: ConditionStyleFormValues) => {
+      const result: ConditionStyleFormValues[] = dataSource.filter(
+        item => item.uid !== values.uid,
+      );
+
+      setDataSource(result);
+      onChange?.(ancestors, {
+        ...myData,
+        value: result,
+      });
+    };
+
+    const tableColumnsSettings: ColumnsType<ConditionStyleFormValues> = [
+      {
+        title: t('conditionStyleTable.header.range.title'),
+        dataIndex: 'range',
+        width: 100,
+        render: (_, { range }) => (
+          <Tag>{t(`conditionStyleTable.header.range.${range}`)}</Tag>
+        ),
+      },
+      {
+        title: t('conditionStyleTable.header.operator'),
+        width: 100,
+        dataIndex: 'operator',
+      },
+      {
+        title: t('conditionStyleTable.header.value'),
+        dataIndex: 'value',
+        render: (_, { value }) => <>{JSON.stringify(value)}</>,
+      },
+      {
+        title: t('conditionStyleTable.header.color.title'),
+        dataIndex: 'value',
+        width: 200,
+        render: (_, { color }) => (
+          <>
+            <Tag color={color.background}>
+              {t('conditionStyleTable.header.color.background')}
+            </Tag>
+            <Tag color={color.text}>
+              {t('conditionStyleTable.header.color.text')}
+            </Tag>
+          </>
+        ),
+      },
+      {
+        title: t('conditionStyleTable.header.action'),
+        dataIndex: 'action',
+        width: 140,
+        render: (_, record) => {
+          return [
+            <Button type="link" key="edit" onClick={() => onEditItem(record)}>
+              {t('conditionStyleTable.btn.edit')}
+            </Button>,
+            <Popconfirm
+              key="remove"
+              placement="topRight"
+              title="确定要删除吗？"
+              onConfirm={() => onRemoveItem(record)}
+            >
+              <Button type="link" danger>
+                {t('conditionStyleTable.btn.remove')}
+              </Button>
+            </Popconfirm>,
+          ];
+        },
+      },
+    ];
+
+    const openConditionStyle = () => {
+      setVisible(true);
+    };
+    const closeConditionStyleModal = () => {
+      setVisible(false);
+      setCurrentItem({} as ConditionStyleFormValues);
+    };
+    const submitConditionStyleModal = (values: ConditionStyleFormValues) => {
+      let result: ConditionStyleFormValues[] = [];
+
+      if (values.uid) {
+        result = dataSource.map(item => {
+          if (item.uid === values.uid) {
+            return values;
+          }
+          return item;
+        });
+      } else {
+        result = [...dataSource, { ...values, uid: uuidv4() }];
+      }
+
+      setDataSource(result);
+      closeConditionStyleModal();
+      onChange?.(ancestors, {
+        ...myData,
+        value: result,
+      });
+    };
+
+    return (
+      <StyledConditionStylePanel direction="vertical">
+        <Button type="primary" onClick={openConditionStyle}>
+          {t('conditionStyleTable.btn.add')}
+        </Button>
+        <Row gutter={24}>
+          <Col span={24}>
+            <Table<ConditionStyleFormValues>
+              bordered={true}
+              size="small"
+              pagination={false}
+              rowKey={record => record.uid!}
+              columns={tableColumnsSettings}
+              dataSource={dataSource}
+            />
+          </Col>
+        </Row>
+        <AddModal
+          currentSelectedItem={currentSelectedItem}
+          visible={visible}
+          translate={t}
+          values={currentItem}
+          onOk={submitConditionStyleModal}
+          onCancel={closeConditionStyleModal}
+        />
+      </StyledConditionStylePanel>
+    );
+  },
+  itemLayoutComparer,
+);
+
+const StyledConditionStylePanel = styled(Space)`
+  width: 100%;
+  margin-top: 10px;
+`;
+
+export default ConditionStylePanel;

--- a/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/type.ts
+++ b/frontend/src/app/components/FormGenerator/Customize/ConditionStylePanel/type.ts
@@ -1,0 +1,65 @@
+import { ColumnTypes } from 'app/pages/MainPage/pages/ViewPage/constants';
+
+export enum ConditionStyleRange {
+  Cell = 'cell',
+  Row = 'row',
+}
+
+export enum OperatorTypes {
+  Equal = '=',
+  NotEqual = '!=',
+  Contain = 'like',
+  NotContain = 'not like',
+  Between = 'between',
+  In = 'in',
+  NotIn = 'not in',
+  LessThan = '<',
+  GreaterThan = '>',
+  LessThanOrEqual = '<=',
+  GreaterThanOrEqual = '>=',
+  IsNull = 'is null',
+}
+
+export const OperatorTypesLocale = {
+  [OperatorTypes.Equal]: '等于',
+  [OperatorTypes.NotEqual]: '不等于',
+  [OperatorTypes.Contain]: '包含',
+  [OperatorTypes.NotContain]: '不包含',
+  [OperatorTypes.In]: '在……范围内',
+  [OperatorTypes.NotIn]: '不在……范围内',
+  [OperatorTypes.Between]: '在……之间',
+  [OperatorTypes.LessThan]: '小于',
+  [OperatorTypes.GreaterThan]: '大于',
+  [OperatorTypes.LessThanOrEqual]: '小于等于',
+  [OperatorTypes.GreaterThanOrEqual]: '大于等于',
+  [OperatorTypes.IsNull]: '空值',
+};
+
+export const ConditionOperatorTypes = {
+  [ColumnTypes.String]: [
+    OperatorTypes.Equal,
+    OperatorTypes.NotEqual,
+    OperatorTypes.Contain,
+    OperatorTypes.NotContain,
+    OperatorTypes.In,
+    OperatorTypes.NotIn,
+    OperatorTypes.IsNull,
+  ],
+  [ColumnTypes.Number]: [
+    OperatorTypes.Equal,
+    OperatorTypes.NotEqual,
+    OperatorTypes.Between,
+    OperatorTypes.LessThan,
+    OperatorTypes.GreaterThan,
+    OperatorTypes.LessThanOrEqual,
+    OperatorTypes.GreaterThanOrEqual,
+    OperatorTypes.IsNull,
+  ],
+  [ColumnTypes.Date]: [
+    OperatorTypes.Equal,
+    OperatorTypes.NotEqual,
+    OperatorTypes.In,
+    OperatorTypes.NotIn,
+    OperatorTypes.IsNull,
+  ],
+};

--- a/frontend/src/app/components/FormGenerator/Customize/ListTemplatePanel.tsx
+++ b/frontend/src/app/components/FormGenerator/Customize/ListTemplatePanel.tsx
@@ -135,6 +135,7 @@ const ListTemplatePanel: FC<ItemLayoutProps<ChartStyleSectionConfig>> = memo(
           mode={GroupLayoutMode.INNER}
           data={r}
           translate={t}
+          currentSelectedItem={currentSelectedItem}
           onChange={handleChildComponentUpdate(r.key)}
         />
       );

--- a/frontend/src/app/components/FormGenerator/Customize/index.ts
+++ b/frontend/src/app/components/FormGenerator/Customize/index.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+export { default as ConditionStylePanel } from './ConditionStylePanel';
 export { default as DataCachePanel } from './DataCachePanel';
 export { default as DataReferencePanel } from './DataReferencePanel';
 export { default as ListTemplatePanel } from './ListTemplatePanel';

--- a/frontend/src/app/components/FormGenerator/Layout/CollectionLayout.tsx
+++ b/frontend/src/app/components/FormGenerator/Layout/CollectionLayout.tsx
@@ -41,34 +41,46 @@ import { groupLayoutComparer } from '../utils';
 import ItemLayout from './ItemLayout';
 
 const CollectionLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> =
-  memo(({ ancestors, translate, data, dataConfigs, flatten, onChange }) => {
-    const getDependencyValue = useCallback((watcher, children) => {
-      if (watcher?.deps) {
-        // Note: only support depend on one property for now.
-        const dependencyKey = watcher?.deps?.[0];
-        return children?.find(r => r.key === dependencyKey)?.value;
-      }
-    }, []);
+  memo(
+    ({
+      ancestors,
+      translate,
+      data,
+      dataConfigs,
+      flatten,
+      currentSelectedItem,
+      onChange,
+    }) => {
+      const getDependencyValue = useCallback((watcher, children) => {
+        if (watcher?.deps) {
+          // Note: only support depend on one property for now.
+          const dependencyKey = watcher?.deps?.[0];
+          return children?.find(r => r.key === dependencyKey)?.value;
+        }
+      }, []);
 
-    return (
-      <StyledCollectionLayout>
-        {data?.rows
-          ?.filter(r => Boolean(!r.hide))
-          .map((r, index) => (
-            <ItemLayout
-              ancestors={ancestors.concat([index])}
-              key={r.key}
-              data={r}
-              translate={translate}
-              dependency={getDependencyValue(r.watcher, data?.rows)}
-              dataConfigs={dataConfigs}
-              flatten={flatten}
-              onChange={onChange}
-            />
-          ))}
-      </StyledCollectionLayout>
-    );
-  }, groupLayoutComparer);
+      return (
+        <StyledCollectionLayout>
+          {data?.rows
+            ?.filter(r => Boolean(!r.hide))
+            .map((r, index) => (
+              <ItemLayout
+                ancestors={ancestors.concat([index])}
+                key={r.key}
+                data={r}
+                translate={translate}
+                dependency={getDependencyValue(r.watcher, data?.rows)}
+                dataConfigs={dataConfigs}
+                flatten={flatten}
+                currentSelectedItem={currentSelectedItem}
+                onChange={onChange}
+              />
+            ))}
+        </StyledCollectionLayout>
+      );
+    },
+    groupLayoutComparer,
+  );
 
 export default CollectionLayout;
 

--- a/frontend/src/app/components/FormGenerator/Layout/GroupLayout.tsx
+++ b/frontend/src/app/components/FormGenerator/Layout/GroupLayout.tsx
@@ -40,6 +40,7 @@ const GroupLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> = memo(
     translate: t = title => title,
     dataConfigs,
     flatten,
+    currentSelectedItem,
     onChange,
   }) => {
     const [openStateModal, contextHolder] = useStateModal({});
@@ -111,6 +112,7 @@ const GroupLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> = memo(
           translate={t}
           dataConfigs={dataConfigs}
           flatten={flatten}
+          currentSelectedItem={currentSelectedItem}
           onChange={onChangeEvent}
         />
       );

--- a/frontend/src/app/components/FormGenerator/Layout/ItemLayout.tsx
+++ b/frontend/src/app/components/FormGenerator/Layout/ItemLayout.tsx
@@ -49,6 +49,7 @@ import {
   BasicUnControlledTabPanel,
 } from '../Basic';
 import {
+  ConditionStylePanel,
   DataCachePanel,
   DataReferencePanel,
   ListTemplatePanel,
@@ -67,6 +68,7 @@ const ItemLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> = memo(
     dependency,
     onChange,
     dataConfigs,
+    currentSelectedItem,
     flatten,
   }) => {
     useEffect(() => {
@@ -115,9 +117,9 @@ const ItemLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> = memo(
         data,
         translate,
         onChange: handleDataChange,
+        currentSelectedItem,
         dataConfigs,
       };
-
       switch (data.comType) {
         case ChartStyleSectionComponentType.CHECKBOX:
           return <BasicCheckbox {...props} />;
@@ -155,6 +157,8 @@ const ItemLayout: FC<FormGeneratorLayoutProps<ChartStyleSectionConfig>> = memo(
           return <DataReferencePanel {...props} />;
         case ChartStyleSectionComponentType.TABLEHEADER:
           return <UnControlledTableHeaderPanel {...props} />;
+        case ChartStyleSectionComponentType.CONDITIONSTYLE:
+          return <ConditionStylePanel {...props} />;
         case ChartStyleSectionComponentType.GROUP:
           return <GroupLayout {...props} />;
         case ChartStyleSectionComponentType.TEXT:

--- a/frontend/src/app/components/FormGenerator/types.ts
+++ b/frontend/src/app/components/FormGenerator/types.ts
@@ -20,6 +20,7 @@ export interface ItemLayoutProps<T> {
   ) => void;
   dataConfigs?: ChartDataSectionConfig[];
   flatten?: boolean;
+  currentSelectedItem?: any;
 }
 
 export interface FormGeneratorLayoutProps<T> extends ItemLayoutProps<T> {

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/BasicTableChart/conditionStyle.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/BasicTableChart/conditionStyle.ts
@@ -1,0 +1,135 @@
+import { ConditionStyleFormValues } from 'app/components/FormGenerator/Customize/ConditionStylePanel';
+import { OperatorTypes } from 'app/components/FormGenerator/Customize/ConditionStylePanel/type';
+import { CSSProperties } from 'react';
+
+const hasMatchedTheCondition = (
+  value: string | number,
+  operatorType: OperatorTypes,
+  conditionValues: string | number | (string | number)[],
+) => {
+  let matchTheCondition = false;
+
+  switch (operatorType) {
+    case OperatorTypes.Equal:
+      matchTheCondition = value === conditionValues;
+      break;
+    case OperatorTypes.NotEqual:
+      matchTheCondition = value !== conditionValues;
+      break;
+    case OperatorTypes.Contain:
+      matchTheCondition = (value as string).includes(conditionValues as string);
+      break;
+    case OperatorTypes.NotContain:
+      matchTheCondition = !(value as string).includes(
+        conditionValues as string,
+      );
+      break;
+    case OperatorTypes.In:
+      matchTheCondition = (conditionValues as (string | number)[]).includes(
+        value,
+      );
+      break;
+    case OperatorTypes.NotIn:
+      matchTheCondition = !(conditionValues as (string | number)[]).includes(
+        value,
+      );
+      break;
+    case OperatorTypes.Between:
+      const [min, max] = conditionValues as number[];
+      matchTheCondition = value >= min && value <= max;
+      break;
+    case OperatorTypes.LessThan:
+      matchTheCondition = value < conditionValues;
+      break;
+    case OperatorTypes.GreaterThan:
+      matchTheCondition = value > conditionValues;
+      break;
+    case OperatorTypes.LessThanOrEqual:
+      matchTheCondition = value <= conditionValues;
+      break;
+    case OperatorTypes.GreaterThanOrEqual:
+      matchTheCondition = value >= conditionValues;
+      break;
+    case OperatorTypes.IsNull:
+      if (typeof value === 'object' && value === null) {
+        matchTheCondition = true;
+      } else if (typeof value === 'string' && value === '') {
+        matchTheCondition = true;
+      } else if (typeof value === 'undefined') {
+        matchTheCondition = true;
+      } else {
+        matchTheCondition = false;
+      }
+      break;
+    default:
+      break;
+  }
+  return matchTheCondition;
+};
+
+const getTheSameRange = (list, type) =>
+  list?.filter(({ range }) => range === type);
+
+const getRowRecord = row => {
+  if (!row?.length) {
+    return {};
+  }
+  return row[0]?.props?.record || {};
+};
+
+export const getCustomBodyCellStyle = (
+  props: any,
+  conditionStyle: ConditionStyleFormValues[],
+): CSSProperties => {
+  const currentConfig = getTheSameRange(conditionStyle, 'cell');
+  if (!currentConfig || currentConfig?.length === 0) {
+    return {};
+  }
+  const text = props.cellValue;
+  let cellStyle: CSSProperties = {};
+
+  try {
+    currentConfig.forEach(
+      ({ operator, value, color: { background, text: color } }) => {
+        cellStyle = hasMatchedTheCondition(text, operator, value)
+          ? { backgroundColor: background, color: color }
+          : cellStyle;
+      },
+    );
+  } catch (error) {}
+
+  return cellStyle;
+};
+
+export const getCustomBodyRowStyle = (
+  props: any,
+  conditionStyle: ConditionStyleFormValues[],
+): CSSProperties => {
+  const currentConfig: ConditionStyleFormValues[] = getTheSameRange(
+    conditionStyle,
+    'row',
+  );
+  if (!currentConfig || currentConfig?.length === 0) {
+    return {};
+  }
+
+  const rowRecord = getRowRecord(props.children);
+  let rowStyle: CSSProperties = {};
+
+  try {
+    currentConfig.forEach(
+      ({
+        operator,
+        value,
+        color: { background, text: color },
+        target: { name },
+      }) => {
+        rowStyle = hasMatchedTheCondition(rowRecord[name], operator, value)
+          ? { backgroundColor: background, color: color }
+          : rowStyle;
+      },
+    );
+  } catch (error) {}
+
+  return rowStyle;
+};

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/BasicTableChart/config.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/BasicTableChart/config.ts
@@ -80,6 +80,7 @@ const config: ChartConfig = {
                     .map(c => ({
                       key: c.uid,
                       value: c.uid,
+                      type: c.type,
                       label:
                         c.label || c.aggregate
                           ? `${c.aggregate}(${c.colName})`
@@ -162,7 +163,13 @@ const config: ChartConfig = {
                     key: 'conditionStyle',
                     comType: 'group',
                     options: { expand: true },
-                    rows: [],
+                    rows: [
+                      {
+                        label: 'column.conditionStylePanel',
+                        key: 'conditionStylePanel',
+                        comType: 'conditionStylePanel',
+                      },
+                    ],
                   },
                 ],
               },
@@ -332,6 +339,7 @@ const config: ChartConfig = {
           enableSort: '开启列排序',
           basicStyle: '基础样式',
           conditionStyle: '条件样式',
+          conditionStylePanel: '条件样式配置器',
           backgroundColor: '背景颜色',
           align: '对齐方式',
           enableFixedCol: '开启固定列宽',
@@ -377,6 +385,7 @@ const config: ChartConfig = {
           enableSort: 'Enable Sort',
           basicStyle: 'Baisc Style',
           conditionStyle: 'Condition Style',
+          conditionStylePanel: 'Condition Style Panel',
           backgroundColor: 'Background Color',
           align: 'Align',
           enableFixedCol: 'Enable Fixed Column',

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/FenZuTableChart/config.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/FenZuTableChart/config.ts
@@ -70,6 +70,7 @@ const config: ChartConfig = {
                     .map(c => ({
                       key: c.uid,
                       value: c.uid,
+                      type: c.type,
                       label:
                         c.label || c.aggregate
                           ? `${c.aggregate}(${c.colName})`
@@ -139,7 +140,13 @@ const config: ChartConfig = {
                     key: 'conditionStyle',
                     comType: 'group',
                     options: { expand: true },
-                    rows: [],
+                    rows: [
+                      {
+                        label: 'column.conditionStylePanel',
+                        key: 'conditionStylePanel',
+                        comType: 'conditionStylePanel',
+                      },
+                    ],
                   },
                 ],
               },
@@ -267,6 +274,7 @@ const config: ChartConfig = {
           enableSort: '开启列排序',
           basicStyle: '基础样式',
           conditionStyle: '条件样式',
+          conditionStylePanel: '条件样式配置器',
           backgroundColor: '背景颜色',
           align: '对齐方式',
           enableFixedCol: '开启固定列宽',

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/MingXiTableChart/config.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartGraph/MingXiTableChart/config.ts
@@ -79,6 +79,7 @@ const config: ChartConfig = {
                     .map(c => ({
                       key: c.uid,
                       value: c.uid,
+                      type: c.type,
                       label:
                         c.label || c.aggregate
                           ? `${c.aggregate}(${c.colName})`
@@ -161,7 +162,13 @@ const config: ChartConfig = {
                     key: 'conditionStyle',
                     comType: 'group',
                     options: { expand: true },
-                    rows: [],
+                    rows: [
+                      {
+                        label: 'column.conditionStylePanel',
+                        key: 'conditionStylePanel',
+                        comType: 'conditionStylePanel',
+                      },
+                    ],
                   },
                 ],
               },
@@ -331,6 +338,7 @@ const config: ChartConfig = {
           enableSort: '开启列排序',
           basicStyle: '基础样式',
           conditionStyle: '条件样式',
+          conditionStylePanel: '条件样式配置器',
           backgroundColor: '背景颜色',
           align: '对齐方式',
           enableFixedCol: '开启固定列宽',
@@ -376,6 +384,7 @@ const config: ChartConfig = {
           enableSort: 'Enable Sort',
           basicStyle: 'Baisc Style',
           conditionStyle: 'Condition Style',
+          conditionStylePanel: 'Condition Style Panel',
           backgroundColor: 'Background Color',
           align: 'Align',
           enableFixedCol: 'Enable Fixed Column',

--- a/frontend/src/app/pages/ChartWorkbenchPage/models/Chart.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/models/Chart.ts
@@ -119,7 +119,7 @@ class Chart extends DatartChartBase {
     return series?.data?.valueColName || series.seriesName;
   }
 
-  private getValue(
+  protected getValue(
     configs: ChartStyleSectionConfig[] = [],
     paths?: string[],
     targetKey?,

--- a/frontend/src/app/types/ChartConfig.ts
+++ b/frontend/src/app/types/ChartConfig.ts
@@ -187,6 +187,7 @@ export const ChartStyleSectionComponentType = {
   LINE: 'line',
   MARGIN_WIDTH: 'marginWidth',
   TEXT: 'text',
+  CONDITIONSTYLE: 'conditionStyle',
 };
 
 type ChartConfigBase = {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -197,6 +197,28 @@
             }
           }
         },
+        "conditionStyleTable": {
+          "btn": {
+            "add": "Add",
+            "edit": "Edit",
+            "remove": "Remove"
+          },
+          "header": {
+            "operator": "Operator",
+            "value": "Value",
+            "color": {
+              "title": "Color",
+              "background": "Background",
+              "text": "Text"
+            },
+            "range": {
+              "title": "Applied range",
+              "cell": "Cell",
+              "row": "Row"
+            },
+            "action": "Action"
+          }
+        },
         "visualMap": {
           "title": "Visual Map",
           "show": "Show Visual Map",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -198,6 +198,28 @@
             }
           }
         },
+        "conditionStyleTable": {
+          "btn": {
+            "add": "新增",
+            "edit": "编辑",
+            "remove": "删除"
+          },
+          "header": {
+            "operator": "关系",
+            "value": "值",
+            "color": {
+              "title": "颜色",
+              "background": "背景",
+              "text": "文字"
+            },
+            "range": {
+              "title": "应用范围",
+              "cell": "单元格",
+              "row": "整行"
+            },
+            "action": "操作"
+          }
+        },
         "visualMap": {
           "title": "视觉映射",
           "show": "显示视觉映射",


### PR DESCRIPTION
大概思路：
基于现有的`json config`配置递归渲染节点的逻辑。插入条件格式的json配置项，并在其循环递归之处引入`条件格式`的配置器。
table相关基于现有components逻辑，增加对其条件格式样式的补充。

界面效果：
预览效果
![图片](https://user-images.githubusercontent.com/95753485/145351227-d3e276ba-68c1-4c48-9046-96c98bb325c2.png)
控制器效果
![图片](https://user-images.githubusercontent.com/95753485/145351281-8682ec59-4729-4f42-af72-62a061ec68ad.png)
编辑效果
![图片](https://user-images.githubusercontent.com/95753485/145354749-d0f59f77-75c4-488c-ae33-5ec33d155840.png)
