### PR TITLE
fix: 修复闪烁404的问题

### DIFF
--- a/frontend/src/app/pages/MainPage/index.tsx
+++ b/frontend/src/app/pages/MainPage/index.tsx
@@ -86,11 +86,11 @@ export function MainPage() {
     }
   }, [dispatch, vizActions, viewActions, orgId]);
 
-  useEffect(() => {
-    if (isExact && orgId) {
-      history.push(`/organizations/${orgId}`);
-    }
-  }, [isExact, orgId, history]);
+  // useEffect(() => {
+  //   if (isExact && orgId) {
+  //     history.push(`/organizations/${orgId}`);
+  //   }
+  // }, [isExact, orgId, history]);
 
   return (
     <AppContainer>
@@ -98,6 +98,11 @@ export function MainPage() {
       <Navbar />
       {orgId && (
         <Switch>
+          {orgId ? (
+            <Route path="/" exact>
+              <Redirect to={`/organizations/${orgId}`} />
+            </Route>
+          ) : null}
           <Route path="/confirminvite" component={ConfirmInvitePage} />
           <Route path="/organizations/:orgId" exact>
             <Redirect


### PR DESCRIPTION
必现操作
1.点击datart Icon 会闪烁404

原因
useEffect的原因，对于‘/’路由必然会有一瞬间的匹配失败，从而导致进入了404匹配项。

解决方式
放弃useEffect劫持方式，通过Route劫持然后Redirect，直接从界面渲染源头解决

问题展示
![iShot2021-12-29 15 29 13](https://user-images.githubusercontent.com/95753485/147637831-0cc73440-ab99-4b07-af13-511f45b69afd.gif)

