### PR TITLE
fix: 删除文件及其目录之后回收站无法打开

### DIFF
--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -230,7 +230,10 @@ export function getPath<T extends { id: string; parentId: string | null }>(
   path: string[] = [],
 ) {
   if (!item?.parentId) {
-    return [rootId].concat(item.id).concat(path);
+    if (item) {
+      return [rootId].concat(item.id).concat(path);
+    }
+    return [rootId].concat(path);
   } else {
     const parent = list.find(({ id }) => id === item.parentId)!;
     return getPath(list, parent, rootId, [item.id].concat(path));
@@ -348,4 +351,3 @@ export function fastDeleteArrayElement(arr: any[], index: number) {
   arr[index] = arr[arr.length - 1];
   arr.pop();
 }
-


### PR DESCRIPTION
复现步骤
1.新建一个数据源和目录
2.将数据源移动新建好的目录下
3.删除数据源
4.删除目录
5.进入回收站
6.页面报错

bug场景
![Filmage 2022-01-05_170609](https://user-images.githubusercontent.com/95753485/148195555-75a3fcd1-848f-4286-9540-f72c3d5b9c46.gif)

