### PR TITLE
fix: 数据视图为空时 仪表盘添加该数据视图 页面崩溃

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/components/WidgetToolBar/WidgetActionDropdown.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/WidgetToolBar/WidgetActionDropdown.tsx
@@ -117,10 +117,10 @@ export const WidgetActionDropdown: React.FC<WidgetActionDropdownProps> = memo(
           allList: getAllList(),
           widget,
           boardEditing,
-          chartGraphId: dataChart?.config.chartGraphId,
+          chartGraphId: dataChart?.config?.chartGraphId,
         }) || []
       );
-    }, [boardEditing, dataChart?.config.chartGraphId, getAllList, widget]);
+    }, [boardEditing, dataChart?.config?.chartGraphId, getAllList, widget]);
     const dropdownList = useMemo(() => {
       const menuItems = actionList.map(item => {
         return (


### PR DESCRIPTION
重现步骤
1.新建一个数据视图  不要进行编辑 保证该视图图表为空
2.找一个仪表盘
3.“添加已有数据图表”，选中刚刚新建的那个视图
4.界面崩溃