### PR TITLE
feat(chart): add i18n translater to chart lifecycle

### DIFF
--- a/frontend/src/app/components/ChartGraph/BasicBarChart/BasicBarChart.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicBarChart/BasicBarChart.tsx
@@ -73,7 +73,7 @@ class BasicBarChart extends Chart {
     });
   }
 
-  onUpdated(options): void {
+  onUpdated(options, context): void {
     if (!options.dataset || !options.dataset.columns || !options.config) {
       return;
     }

--- a/frontend/src/app/components/ChartIFrameContainer/ChartIFrameContainer.tsx
+++ b/frontend/src/app/components/ChartIFrameContainer/ChartIFrameContainer.tsx
@@ -20,6 +20,7 @@ import {
   Frame,
   FrameContextConsumer,
 } from 'app/components/ReactFrameComponent';
+import ChartI18NContext from 'app/pages/ChartWorkbenchPage/contexts/Chart18NContext';
 import { IChart } from 'app/types/Chart';
 import { ChartConfig } from 'app/types/ChartConfig';
 import { FC, memo } from 'react';
@@ -109,7 +110,11 @@ const ChartIFrameContainer: FC<{
     );
   };
 
-  return render();
+  return (
+    <ChartI18NContext.Provider value={{ i18NConfigs: props?.config?.i18ns }}>
+      {render()}
+    </ChartI18NContext.Provider>
+  );
 });
 
 export default ChartIFrameContainer;

--- a/frontend/src/app/components/ChartIFrameContainer/ChartIFrameEventBroker.ts
+++ b/frontend/src/app/components/ChartIFrameContainer/ChartIFrameEventBroker.ts
@@ -25,6 +25,7 @@ type BrokerContext = {
   document?: any;
   width?: any;
   height?: any;
+  translator?: (key, disablePrefix, options) => string;
 };
 
 type HooksEvent = 'mounted' | 'updated' | 'resize' | 'unmount';

--- a/frontend/src/app/components/ChartIFrameContainer/ChartIFrameLifecycleAdapter.tsx
+++ b/frontend/src/app/components/ChartIFrameContainer/ChartIFrameLifecycleAdapter.tsx
@@ -19,6 +19,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { Spin } from 'antd';
 import { useFrame } from 'app/components/ReactFrameComponent';
+import usePrefixI18N from 'app/hooks/useI18NPrefix';
 import { IChart } from 'app/types/Chart';
 import { ChartConfig } from 'app/types/ChartConfig';
 import { ChartLifecycle } from 'app/types/ChartLifecycle';
@@ -55,6 +56,7 @@ const ChartIFrameLifecycleAdapter: FC<{
   const { document, window } = useFrame();
   const [containerId] = useState(() => uuidv4());
   const eventBrokerRef = useRef<ChartIFrameEventBroker>();
+  const translator = usePrefixI18N();
 
   /**
    * Chart Mount Event
@@ -88,6 +90,7 @@ const ChartIFrameLifecycleAdapter: FC<{
               window,
               width: style?.width,
               height: style?.height,
+              translator,
             },
           );
           eventBrokerRef.current = newBrokerRef;
@@ -103,7 +106,7 @@ const ChartIFrameLifecycleAdapter: FC<{
       eventBrokerRef?.current?.publish(ChartLifecycle.UNMOUNTED, {});
       eventBrokerRef?.current?.dispose();
     };
-  }, [chart?.meta?.id, eventBrokerRef, isShown]);
+  }, [chart?.meta?.id, eventBrokerRef, isShown, translator]);
 
   /**
    * Chart Update Event
@@ -132,6 +135,7 @@ const ChartIFrameLifecycleAdapter: FC<{
         window,
         width: style?.width,
         height: style?.height,
+        translator,
       },
     );
   }, [
@@ -142,6 +146,7 @@ const ChartIFrameLifecycleAdapter: FC<{
     document,
     window,
     isShown,
+    translator,
   ]);
 
   /**
@@ -172,9 +177,10 @@ const ChartIFrameLifecycleAdapter: FC<{
         window,
         width: style?.width,
         height: style?.height,
+        translator,
       },
     );
-  }, [style.width, style.height, document, window, isShown]);
+  }, [style.width, style.height, document, window, isShown, translator]);
 
   return (
     <Spin

--- a/frontend/src/app/hooks/useI18NPrefix.ts
+++ b/frontend/src/app/hooks/useI18NPrefix.ts
@@ -40,7 +40,7 @@ function usePrefixI18N(prefix?: string) {
       let translationKey = key;
       const usePrefix =
         !disablePrefix && !translationKey.includes(DATART_TRANSLATE_HOLDER);
-      if (usePrefix) {
+      if (usePrefix && prefix) {
         translationKey = `${prefix}.${translationKey}`;
       }
       if (translationKey.includes(DATART_TRANSLATE_HOLDER)) {


### PR DESCRIPTION
## Sample
console.log(
      `translator ---> `,
      context?.translator?.('common.showAxis'),
      context?.translator?.('viz.palette.graph.names.barChart'),
    );