### PR TITLE
fix: 修复翻牌器/富文本的部分问题

### DIFF
--- a/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
@@ -120,7 +120,8 @@ const ChartRichTextAdapter: FC<{
             const config = name
               ? dataList.find(items => items.name === name)
               : null;
-            insert = config?.value || '';
+            if (typeof config.value === 'number') insert = String(config.value);
+            else insert = config?.value || '';
           }
         }
         return { ...item, insert };

--- a/frontend/src/app/components/ChartGraph/ScoreChart/ScoreChart.tsx
+++ b/frontend/src/app/components/ChartGraph/ScoreChart/ScoreChart.tsx
@@ -150,7 +150,7 @@ class ScoreChart extends Chart {
         {
           type: 'scatter',
           data: [[0, 0]],
-          symbolSize: 1,
+          symbolSize: 0,
           label: {
             normal: {
               show: true,
@@ -206,12 +206,12 @@ class ScoreChart extends Chart {
     aggregateConfigs: any[],
     index: number,
   ) {
-    return (
-      toFormattedValue(
-        aggConfigValues?.[index],
-        aggregateConfigs?.[index]?.format,
-      ) || ''
+    const formattedValue = toFormattedValue(
+      aggConfigValues?.[index],
+      aggregateConfigs?.[index]?.format,
     );
+    if (typeof formattedValue === 'number') return formattedValue;
+    return formattedValue || '';
   }
 
   private customFormatters(aggConfigValues, aggregateConfigs, styleConfigs) {


### PR DESCRIPTION
本次pr修复了三个问题

- 翻牌器中心有蓝色小点，鼠标移动到上方会变大。
查阅代码，发现翻牌器的实现是借助了scatter图表，通过label展示实现的，所谓的蓝色小点其实是默认的一个scatter元素，控制下symbolSize即可
- 翻牌器无法显示**0**
**||** 运算符，吃掉**0**的问题，判断类型处理一下即可
- 富文本无法显示**0**
富文本使用的react-quill插件，而value使用了**Delta**格式，查阅[官方文档](http://github.com/quilljs/delta/#insert-operation)/[TS类型](https://github.com/quilljs/delta/blob/main/src/Delta.ts#L27)可知，insert的值只对string及特定obj友好。所以在把number转为string