### PR TITLE
图表-富文本编辑器添加链接，tooltip 页面边缘遮挡；

### DIFF
--- a/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
@@ -306,7 +306,6 @@ const ChartRichTextAdapter: FC<{
             formats={Formats}
             readOnly={false}
             bounds={'#quill-box'}
-            sco
           />
           <Row align="middle" justify="end" style={{ paddingTop: 16 }}>
             <Button

--- a/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicRichText/ChartRichTextAdapter.tsx
@@ -31,7 +31,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
+  useState
 } from 'react';
 import ReactQuill, { Quill } from 'react-quill';
 import 'react-quill/dist/quill.bubble.css';
@@ -40,7 +40,7 @@ import styled from 'styled-components/macro';
 import './RichTextPluginLoader';
 import {
   Formats,
-  MarkdownOptions,
+  MarkdownOptions
 } from './RichTextPluginLoader/RichTextConfig';
 import TagBlot from './RichTextPluginLoader/TagBlot';
 
@@ -305,6 +305,8 @@ const ChartRichTextAdapter: FC<{
             modules={quillModules}
             formats={Formats}
             readOnly={false}
+            bounds={'#quill-box'}
+            sco
           />
           <Row align="middle" justify="end" style={{ paddingTop: 16 }}>
             <Button
@@ -327,7 +329,7 @@ const ChartRichTextAdapter: FC<{
 
   return (
     <TextWrap onClick={ssp}>
-      <QuillBox>
+      <QuillBox id="quill-box">
         {quillModules && reactQuillEdit}
         {quillModules && !isEditing && reactQuillView}
       </QuillBox>


### PR DESCRIPTION
修复前:
![image](https://user-images.githubusercontent.com/7060489/151468331-86acfb8f-03cb-4505-9dae-1b9ab67f5037.png)
修复后:
![image](https://user-images.githubusercontent.com/7060489/151468387-c6608e5c-fb46-4905-9771-0720179c834e.png)
