### PR TITLE
fix: 修复editor自动补全重复注册的问题

### DIFF
--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Editor/SQLEditor.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Editor/SQLEditor.tsx
@@ -130,7 +130,6 @@ export const SQLEditor = memo(() => {
       dispatch(
         getEditorProvideCompletionItems({
           resolve: getItems => {
-            editorCompletionItemProviderRef?.current?.dispose();
             const providerRef = editor.languages.registerCompletionItemProvider(
               'sql',
               {
@@ -176,6 +175,7 @@ export const SQLEditor = memo(() => {
     editorInstance?.layout();
     return () => {
       editorInstance?.dispose();
+      editorCompletionItemProviderRef?.current?.dispose();
     };
   }, [editorInstance]);
 


### PR DESCRIPTION
问题场景：
1.进入views sql编辑页面，然后输入**sel**，monaco会补全提示**SELECT**,当前是正常情况
2.此时直接通过侧边栏进入vizs页面，不做任何事情
3.再次重复步骤1，会发现输入**sel**,**SELECT**会多次注册,步骤1和步骤2重复操作10次，自动补全就会重复注册10次。

<img width="603" alt="图片" src="https://user-images.githubusercontent.com/95753485/154191246-5d18b7ae-6bea-4a98-8c10-19be20a3d9b9.png">

解决思路：
从views切换到vizs，**EditorContext**组件被销毁，变量会被销毁，所以二次进入views时，其**editorCompletionItemProviderRef**值为undefined，永远也无法销毁之前的自动补全。
