### PR TITLE
fix: 仪表盘销毁后请求完成导致弹出errorMessage

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/pages/Board/slice/index.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/Board/slice/index.ts
@@ -231,6 +231,7 @@ const boardSlice = createSlice({
       }>,
     ) {
       const { boardId, widgetId, pageInfo } = action.payload;
+      if (!state.widgetInfoRecord?.[boardId]?.[widgetId]) return;
       state.widgetInfoRecord[boardId][widgetId].pageInfo = pageInfo || {
         pageNo: 1,
       };
@@ -244,6 +245,7 @@ const boardSlice = createSlice({
       }>,
     ) {
       const { boardId, widgetId, errInfo } = action.payload;
+      if (!state.widgetInfoRecord?.[boardId]?.[widgetId]) return;
       state.widgetInfoRecord[boardId][widgetId].errInfo = errInfo;
     },
     resetControlWidgets(


### PR DESCRIPTION
版本beta.1

事故现场：
1.在vizs页面提前挑选一个有数据的仪表盘，但是不要打开，并且保证数据没有被缓存，network开启Slow 3G。
2.打开该仪表盘，仪表盘内部的widget接口在pending的过程中，通过侧边栏切换到views页面。
3.等待接口pending完成，页面会提示异常信息。

解决方案：
vizs跳转views，vizs部分数据卸载，ajax回调逻辑找不到对应数据，应提前进行数据有效性验证。

<img width="1133" alt="图片" src="https://user-images.githubusercontent.com/95753485/154472167-fea65f65-5660-4e39-8b80-c72f78c07d79.png">
