### PR TITLE
refactor: text vertical alignment of rich text media widget

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -847,7 +847,8 @@
         "autoPlay": "Auto Play",
         "duration": "Duration (s) ",
         "delPagesTip": "Confirm to delete all selected story pages?",
-        "delPageTip": "Confirm to delete this story page?"
+        "delPageTip": "Confirm to delete this story page?",
+        "enterHere": "Enter here"
       }
     },
     "widget": {

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -847,7 +847,8 @@
         "autoPlay": "自动播放",
         "duration": "停留时间(秒)",
         "delPagesTip": "确认删除所有选中的故事页",
-        "delPageTip": "确认删除此故事页？"
+        "delPageTip": "确认删除此故事页？",
+        "enterHere": "请输入"
       }
     },
     "widget": {


### PR DESCRIPTION
### 仪表板媒体组件“富文本”样式、编辑交互重构

#### 1. 样式

在文字内容未撑满容器时，垂直对齐方式在重构前为顶部对齐，重构之后为居中对齐，以便于满足更多的使用场景（如标题）

![image](https://user-images.githubusercontent.com/4098913/156494727-20226c1b-37c1-4d10-9d92-d632237b71e5.png)
![image](https://user-images.githubusercontent.com/4098913/156494703-36664985-0e93-4187-98ce-4ee2b4039b30.png)

在文字内容撑满或超过容器高度时，与重构之前没有区别

![image](https://user-images.githubusercontent.com/4098913/156495077-ee8f2a4a-6410-40e0-9afa-9d11e0902bc2.png)
![image](https://user-images.githubusercontent.com/4098913/156495051-7dd25e7f-c6f8-4769-b4c5-40d9ec21d979.png)

#### 2. 编辑交互

编辑交互重构为双击后弹窗编辑，弹窗为固定宽度，以便于完整显示工具栏。点击确认后保存编辑内容，点击取消不会保存

![image](https://user-images.githubusercontent.com/4098913/156495283-a381413e-5625-4938-b55c-b85d90ac6ec7.png)
