### PR TITLE
fix: Close the request sharing list after entering the dashboard

### DIFF
--- a/frontend/src/app/components/VizHeader/VizHeader.tsx
+++ b/frontend/src/app/components/VizHeader/VizHeader.tsx
@@ -171,7 +171,7 @@ const VizHeader: FC<{
             </>
           }
         />
-        {showShareLinkModal && (
+        {allowShare && (
           <ShareManageModal
             vizId={backendChartId as string}
             orgId={orgId as string}

--- a/frontend/src/app/components/VizOperationMenu/components/ShareLinkModal.tsx
+++ b/frontend/src/app/components/VizOperationMenu/components/ShareLinkModal.tsx
@@ -28,6 +28,7 @@ import {
   getMembers,
   getRoles,
 } from 'app/pages/MainPage/pages/MemberPage/slice/thunks';
+import { selectIsOrgOwner } from 'app/pages/MainPage/slice/selectors';
 import { TIME_FORMATTER } from 'globalConstants';
 import moment from 'moment';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
@@ -59,6 +60,7 @@ const ShareLinkModal: FC<{
   const [btnLoading, setBtnLoading] = useState<boolean>(false);
   const usersList = useSelector(selectMembers);
   const rolesList = useSelector(rdxSelectRoles);
+  const isOwner = useSelector(selectIsOrgOwner);
 
   const handleOkFn = useCallback(
     async ({
@@ -127,9 +129,11 @@ const ShareLinkModal: FC<{
   }, []);
 
   useEffect(() => {
-    dispatch(getRoles(orgId));
-    dispatch(getMembers(orgId));
-  }, [orgId, dispatch]);
+    if (isOwner) {
+      dispatch(getRoles(orgId));
+      dispatch(getMembers(orgId));
+    }
+  }, [orgId, dispatch, isOwner]);
 
   useEffect(() => {
     shareData && handleDefauleValue(shareData);
@@ -199,40 +203,42 @@ const ShareLinkModal: FC<{
                 </Radio>
               </Radio.Group>
             </FormItemEx>
-            <FormItemEx label={t('share.userOrRole')}>
-              <Space>
-                <StyledSelection
-                  onChange={handleChangeRoles}
-                  placeholder={t('share.selectRole')}
-                  mode="multiple"
-                  maxTagCount={2}
-                  value={selectRoles || []}
-                >
-                  {rolesList?.map((v, i) => {
-                    return (
-                      <Select.Option key={i} value={v.id}>
-                        {v.name}
-                      </Select.Option>
-                    );
-                  })}
-                </StyledSelection>
-                <StyledSelection
-                  onChange={handleChangeMembers}
-                  placeholder={t('share.selectUser')}
-                  mode="multiple"
-                  maxTagCount={2}
-                  value={selectUsers || []}
-                >
-                  {usersList?.map((v, i) => {
-                    return (
-                      <Select.Option key={i} value={v.id}>
-                        {v.username}
-                      </Select.Option>
-                    );
-                  })}
-                </StyledSelection>
-              </Space>
-            </FormItemEx>
+            {isOwner && (
+              <FormItemEx label={t('share.userOrRole')}>
+                <Space>
+                  <StyledSelection
+                    onChange={handleChangeRoles}
+                    placeholder={t('share.selectRole')}
+                    mode="multiple"
+                    maxTagCount={2}
+                    value={selectRoles || []}
+                  >
+                    {rolesList?.map((v, i) => {
+                      return (
+                        <Select.Option key={i} value={v.id}>
+                          {v.name}
+                        </Select.Option>
+                      );
+                    })}
+                  </StyledSelection>
+                  <StyledSelection
+                    onChange={handleChangeMembers}
+                    placeholder={t('share.selectUser')}
+                    mode="multiple"
+                    maxTagCount={2}
+                    value={selectUsers || []}
+                  >
+                    {usersList?.map((v, i) => {
+                      return (
+                        <Select.Option key={i} value={v.id}>
+                          {v.username}
+                        </Select.Option>
+                      );
+                    })}
+                  </StyledSelection>
+                </Space>
+              </FormItemEx>
+            )}
           </>
         )}
       </Form>

--- a/frontend/src/app/components/VizOperationMenu/components/ShareManageModal.tsx
+++ b/frontend/src/app/components/VizOperationMenu/components/ShareManageModal.tsx
@@ -257,8 +257,10 @@ const ShareManageModal: FC<{
     ]);
 
     useEffect(() => {
-      fetchShareListFn();
-    }, [fetchShareListFn]);
+      if (visibility) {
+        fetchShareListFn();
+      }
+    }, [fetchShareListFn, visibility]);
 
     return (
       <StyledShareLinkModal

--- a/frontend/src/app/pages/StoryBoardPage/components/StoryHeader.tsx
+++ b/frontend/src/app/pages/StoryBoardPage/components/StoryHeader.tsx
@@ -129,7 +129,7 @@ export const StoryHeader: FC<StoryHeaderProps> = memo(
               </Dropdown>
             )}
 
-            {showShareLinkModal && (
+            {allowShare && (
               <ShareManageModal
                 vizId={stroyBoardId as string}
                 orgId={orgId as string}


### PR DESCRIPTION
fix: Close the request sharing list after entering the dashboard
Only organization managers set member permissions when creating shares