### PR TITLE
refactor:adjust drill context-menu interaction

### DIFF
--- a/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
+++ b/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
@@ -67,7 +67,7 @@ const ChartDrillContextMenu: FC<{}> = memo(({ children }) => {
           )}
         {drillOption?.mode !== DrillMode.Expand && (
           <Menu.Item key="selectDrillStatus">
-            <MenuSwitch
+            <StyledMenuSwitch
               className={classnames({ on: !!drillOption?.isSelectedDrill })}
             >
               <p>
@@ -76,7 +76,7 @@ const ChartDrillContextMenu: FC<{}> = memo(({ children }) => {
                   : t('selectDrillOff')}
               </p>
               <CheckOutlined className="icon" />
-            </MenuSwitch>
+            </StyledMenuSwitch>
           </Menu.Item>
         )}
       </StyledChartDrillMenu>
@@ -109,7 +109,7 @@ const StyledChartDrillMenu = styled(Menu)`
   min-width: 200px;
 `;
 
-const MenuSwitch = styled.div`
+const StyledMenuSwitch = styled.div`
   display: flex;
   align-items: center;
 

--- a/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
+++ b/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
@@ -16,35 +16,32 @@
  * limitations under the License.
  */
 
+import { CheckOutlined } from '@ant-design/icons';
 import { Dropdown, Menu } from 'antd';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import { DrillMode } from 'app/models/ChartDrillOption';
 import ChartDrillContext from 'app/pages/ChartWorkbenchPage/contexts/ChartDrillContext';
+import classnames from 'classnames';
 import { FC, memo, useContext, useMemo } from 'react';
 import styled from 'styled-components/macro';
+import { FONT_WEIGHT_MEDIUM, SPACE_SM } from 'styles/StyleConstants';
 
 const ChartDrillContextMenu: FC<{}> = memo(({ children }) => {
   const t = useI18NPrefix(`viz.palette.drill`);
   const { drillOption, onDrillOptionChange } = useContext(ChartDrillContext);
 
+  const currentDrillLevel = drillOption?.getCurrentDrillLevel();
+
   const contextMenu = useMemo(() => {
     return (
-      <Menu
-        style={{ width: 200 }}
+      <StyledChartDrillMenu
         onClick={({ key }) => {
           if (!drillOption) {
             return;
           }
-          if (key === 'enable') {
-            if (!drillOption?.isSelectedDrill) {
-              drillOption?.toggleSelectedDrill(true);
-              onDrillOptionChange?.(drillOption);
-            }
-          } else if (key === 'disable') {
-            if (drillOption?.isSelectedDrill) {
-              drillOption?.toggleSelectedDrill(false);
-              onDrillOptionChange?.(drillOption);
-            }
+          if (key === 'selectDrillStatus') {
+            drillOption?.toggleSelectedDrill(!drillOption?.isSelectedDrill);
+            onDrillOptionChange?.(drillOption);
           } else if (key === DrillMode.Drill) {
             drillOption?.drillDown();
             onDrillOptionChange?.(drillOption);
@@ -57,34 +54,32 @@ const ChartDrillContextMenu: FC<{}> = memo(({ children }) => {
           }
         }}
       >
-        <Menu.Item key={'rollUp'}>{t('rollUp')}</Menu.Item>
-        <Menu.Item
-          disabled={drillOption?.mode === DrillMode.Expand}
-          key={DrillMode.Drill}
-        >
-          {t('showNextLevel')}
-        </Menu.Item>
-        <Menu.Item
-          disabled={drillOption?.mode === DrillMode.Drill}
-          key={DrillMode.Expand}
-        >
-          {t('expandNextLevel')}
-        </Menu.Item>
-        <Menu.SubMenu
-          disabled={drillOption?.mode === DrillMode.Expand}
-          key="selectDrillStatus"
-          title={t('selectDrillStatus')}
-        >
-          <Menu.Item key="enable" disabled={drillOption?.isSelectedDrill}>
-            {t('enable')}
+        {!!currentDrillLevel && (
+          <Menu.Item key={'rollUp'}>{t('rollUp')}</Menu.Item>
+        )}
+        {drillOption?.mode !== DrillMode.Expand && (
+          <Menu.Item key={DrillMode.Drill}>{t('showNextLevel')}</Menu.Item>
+        )}
+        {drillOption?.mode !== DrillMode.Drill && (
+          <Menu.Item key={DrillMode.Expand}>{t('expandNextLevel')}</Menu.Item>
+        )}
+        {drillOption?.mode !== DrillMode.Expand && (
+          <Menu.Item key="selectDrillStatus">
+            <MenuSwitch
+              className={classnames({ on: !!drillOption?.isSelectedDrill })}
+            >
+              <p>
+                {drillOption?.isSelectedDrill
+                  ? t('selectDrillOn')
+                  : t('selectDrillOff')}
+              </p>
+              <CheckOutlined className="icon" />
+            </MenuSwitch>
           </Menu.Item>
-          <Menu.Item key="disable" disabled={!drillOption?.isSelectedDrill}>
-            {t('disable')}
-          </Menu.Item>
-        </Menu.SubMenu>
-      </Menu>
+        )}
+      </StyledChartDrillMenu>
     );
-  }, [drillOption, t, onDrillOptionChange]);
+  }, [drillOption, currentDrillLevel, t, onDrillOptionChange]);
 
   return (
     <StyledChartDrill className="chart-drill-menu-container">
@@ -106,4 +101,34 @@ export default ChartDrillContextMenu;
 const StyledChartDrill = styled.div`
   position: relative;
   width: 100%;
+`;
+
+const StyledChartDrillMenu = styled(Menu)`
+  min-width: 200px;
+`;
+
+const MenuSwitch = styled.div`
+  display: flex;
+  align-items: center;
+
+  p {
+    flex: 1;
+  }
+
+  .icon {
+    display: none;
+  }
+
+  &.on {
+    p {
+      font-weight: ${FONT_WEIGHT_MEDIUM};
+    }
+
+    .icon {
+      display: block;
+      flex-shrink: 0;
+      padding-left: ${SPACE_SM};
+      color: ${p => p.theme.success};
+    }
+  }
 `;

--- a/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
+++ b/frontend/src/app/components/ChartDrill/ChartDrillContextMenu.tsx
@@ -57,12 +57,14 @@ const ChartDrillContextMenu: FC<{}> = memo(({ children }) => {
         {!!currentDrillLevel && (
           <Menu.Item key={'rollUp'}>{t('rollUp')}</Menu.Item>
         )}
-        {drillOption?.mode !== DrillMode.Expand && (
-          <Menu.Item key={DrillMode.Drill}>{t('showNextLevel')}</Menu.Item>
-        )}
-        {drillOption?.mode !== DrillMode.Drill && (
-          <Menu.Item key={DrillMode.Expand}>{t('expandNextLevel')}</Menu.Item>
-        )}
+        {drillOption?.mode !== DrillMode.Expand &&
+          !drillOption?.isBottomLevel && (
+            <Menu.Item key={DrillMode.Drill}>{t('showNextLevel')}</Menu.Item>
+          )}
+        {drillOption?.mode !== DrillMode.Drill &&
+          !drillOption?.isBottomLevel && (
+            <Menu.Item key={DrillMode.Expand}>{t('expandNextLevel')}</Menu.Item>
+          )}
         {drillOption?.mode !== DrillMode.Expand && (
           <Menu.Item key="selectDrillStatus">
             <MenuSwitch

--- a/frontend/src/app/components/ChartDrill/ChartDrillPaths.tsx
+++ b/frontend/src/app/components/ChartDrill/ChartDrillPaths.tsx
@@ -22,7 +22,7 @@ import ChartDrillContext from 'app/pages/ChartWorkbenchPage/contexts/ChartDrillC
 import { getColumnRenderName } from 'app/utils/chartHelper';
 import { FC, memo, useContext } from 'react';
 import styled from 'styled-components/macro';
-import { SPACE_TIMES } from 'styles/StyleConstants';
+import { SPACE_SM, SPACE_XS } from 'styles/StyleConstants';
 
 const ChartDrillPaths: FC<{}> = memo(() => {
   const { drillOption, onDrillOptionChange } = useContext(ChartDrillContext);
@@ -38,6 +38,7 @@ const ChartDrillPaths: FC<{}> = memo(() => {
         {drilledFields.map(f => {
           return (
             <StyledDrillNode
+              key={f.uid}
               isActive={Boolean(
                 drillOption?.getCurrentFields()?.some(df => df.uid === f.uid),
               )}
@@ -62,11 +63,11 @@ const ChartDrillPaths: FC<{}> = memo(() => {
 export default ChartDrillPaths;
 
 const StyledChartDrillPaths = styled.div`
-  padding-left: ${SPACE_TIMES(2)};
+  padding: ${SPACE_XS} ${SPACE_SM};
 `;
 
 const StyledDrillNode = styled(Breadcrumb.Item)<{ isActive: boolean }>`
+  color: ${p => (p.isActive ? p.theme.primary : p.theme.normal)} !important;
   cursor: pointer;
   user-select: none;
-  color: ${p => (p.isActive ? p.theme.primary : p.theme.normal)} !important;
 `;

--- a/frontend/src/app/models/ChartDrillOption.ts
+++ b/frontend/src/app/models/ChartDrillOption.ts
@@ -59,6 +59,10 @@ export class ChartDrillOption implements IChartDrillOption {
     return this.isSelected;
   }
 
+  public get isBottomLevel() {
+    return this.cursor + 2 === this.drillFields.length;
+  }
+
   public get canSelect() {
     return isEmptyArray(this.expandDownFields);
   }

--- a/frontend/src/app/models/ChartDrillOption.ts
+++ b/frontend/src/app/models/ChartDrillOption.ts
@@ -94,6 +94,10 @@ export class ChartDrillOption implements IChartDrillOption {
       : this.drillFields.slice(0, this.cursor + 2);
   }
 
+  public getCurrentDrillLevel(): number {
+    return this.cursor + 1;
+  }
+
   public drillDown(filterData?: { [key in string]: any }) {
     if (this.drillFields.length === this.cursor + 2) {
       return;
@@ -182,7 +186,6 @@ export class ChartDrillOption implements IChartDrillOption {
 
   private clearAll() {
     this.cursor = -1;
-    this.isSelected = false;
     this.drillDownFields = [];
     this.expandDownFields = [];
   }

--- a/frontend/src/app/pages/MainPage/Navbar/index.tsx
+++ b/frontend/src/app/pages/MainPage/Navbar/index.tsx
@@ -47,6 +47,7 @@ import { downloadFile } from 'app/utils/fetch';
 import { BASE_RESOURCE_URL } from 'globalConstants';
 import { changeLang } from 'locales/i18n';
 import React, { cloneElement, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { NavLink, useHistory, useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -84,6 +85,7 @@ export function Navbar() {
   const [modifyPasswordVisible, setModifyPasswordVisible] = useState(false);
   const dispatch = useDispatch();
   const history = useHistory();
+  const { i18n } = useTranslation();
   const systemInfo = useSelector(selectSystemInfo);
   const orgId = useSelector(selectOrgId);
   const currentOrganization = useSelector(selectCurrentOrganization);
@@ -228,7 +230,9 @@ export function Navbar() {
           break;
         case 'zh':
         case 'en':
-          changeLang(key);
+          if (i18n.language !== key) {
+            changeLang(key);
+          }
           break;
         case 'dark':
         case 'light':
@@ -238,7 +242,7 @@ export function Navbar() {
           break;
       }
     },
-    [dispatch, history, handleChangeThemeFn],
+    [dispatch, history, i18n, handleChangeThemeFn],
   );
 
   const onSetPolling = useCallback(

--- a/frontend/src/app/pages/MainPage/pages/VizPage/ChartPreview/ChartPreview.tsx
+++ b/frontend/src/app/pages/MainPage/pages/VizPage/ChartPreview/ChartPreview.tsx
@@ -159,7 +159,10 @@ const ChartPreviewBoard: FC<{
         {
           name: 'click',
           callback: param => {
-            if (drillOptionRef.current?.isSelectedDrill) {
+            if (
+              drillOptionRef.current?.isSelectedDrill &&
+              !drillOptionRef.current.isBottomLevel
+            ) {
               const option = drillOptionRef.current;
               option.drillDown(param.data.rowData);
               drillOptionRef.current = option;

--- a/frontend/src/app/pages/SharePage/ChartForShare.tsx
+++ b/frontend/src/app/pages/SharePage/ChartForShare.tsx
@@ -184,7 +184,7 @@ const ChartForShare: FC<{
         </div>
         <ChartDrillPaths />
       </ChartDrillContext.Provider>
-      <ChartDrillPaths />x
+      <ChartDrillPaths />
       <HeadlessBrowserIdentifier
         renderSign={headlessBrowserRenderSign}
         width={Number(width) || 0}

--- a/frontend/src/app/types/ChartDrillOption.d.ts
+++ b/frontend/src/app/types/ChartDrillOption.d.ts
@@ -30,6 +30,7 @@ export interface IChartDrillOption {
     condition?: FilterCondition;
   }>;
   getCurrentFields(): ChartDataSectionField[] | undefined;
+  getCurrentDrillLevel(): number;
   drillDown(filterData?: { [key in string]: any }): void;
   expandDown(): void;
   drillUp(field?: ChartDataSectionField): void;

--- a/frontend/src/app/types/ChartDrillOption.d.ts
+++ b/frontend/src/app/types/ChartDrillOption.d.ts
@@ -21,6 +21,7 @@ import { ChartDataSectionField } from 'app/types/ChartConfig';
 export interface IChartDrillOption {
   mode: DrillMode;
   isSelectedDrill: boolean;
+  isBottomLevel: boolean;
   canSelect: boolean;
   toggleSelectedDrill(enable?: boolean): void;
   getAllFields(): ChartDataSectionField[];

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -799,10 +799,9 @@
       },
       "drill": {
         "showNextLevel": "Show Next Level",
-        "expandNextLevel": "Expand Next Level",
-        "selectDrillStatus": "Mouse Click Drill Status",
-        "enable": "Enable",
-        "disable": "Disable",
+        "expandNextLevel": "Expand to Next Level",
+        "selectDrillOn": "\"Click to drill down\" is on",
+        "selectDrillOff": "Turn on \"Click to drill down\"",
         "rollUp": "Roll Up"
       }
     },

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -800,9 +800,8 @@
       "drill": {
         "showNextLevel": "显示下一层级",
         "expandNextLevel": "展开下一层级",
-        "selectDrillStatus": "鼠标点击钻取状态",
-        "enable": "开启",
-        "disable": "关闭",
+        "selectDrillOn": "已开启“点击下钻”",
+        "selectDrillOff": "开启“点击下钻”",
         "rollUp": "上卷"
       }
     },


### PR DESCRIPTION
- 调整钻取右键菜单交互
    - 初始状态不显示上卷菜单
    - 将菜单 disabled 改为不显示
    - 调整“点击下钻”开关样式
    - 调整按钮文字
- 添加钻取交互限制
    - 钻取到最后一级仅显示上卷菜单
    - 开启“点击下钻”时，钻取到最后一级点击图表元素不再发起请求

![image](https://user-images.githubusercontent.com/4098913/163959972-cc80c25f-ee06-42b1-ae4f-7f34ff9ffabc.png)
