### PR TITLE
refactor: data model tree style improvement

### DIFF
--- a/frontend/src/app/components/index.tsx
+++ b/frontend/src/app/components/index.tsx
@@ -11,6 +11,7 @@ export { ListItem } from './ListItem';
 export { ListNav, ListPane } from './ListNav';
 export { ListSwitch } from './ListSwitch';
 export { ListTitle } from './ListTitle';
+export type { ListTitleProps } from './ListTitle';
 export { LoadingMask } from './LoadingMask';
 export { ModalForm } from './ModalForm';
 export type { ModalFormProps } from './ModalForm';

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Container.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Container.tsx
@@ -17,20 +17,26 @@
  */
 
 import { Skeleton } from 'antd';
-import { ListTitle } from 'app/components';
+import { ListTitle, ListTitleProps } from 'app/components';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
-import { FC, memo } from 'react';
+import { FC, memo, ReactNode } from 'react';
 import styled from 'styled-components/macro';
 import { SPACE_TIMES } from 'styles/StyleConstants';
 
-const Container: FC<any> = memo(props => {
+interface ContainerProps extends ListTitleProps {
+  title: string;
+  loading?: boolean;
+  children?: ReactNode;
+}
+
+const Container: FC<ContainerProps> = memo(props => {
   const t = useI18NPrefix('view.properties');
-  const { title, children, isLoading, ...rest } = props;
+  const { title, children, loading, ...rest } = props;
 
   return (
     <StyledContainer>
       <ListTitle title={t(title)} {...rest} />
-      <Skeleton active loading={isLoading}>
+      <Skeleton active loading={loading}>
         {children}
       </Skeleton>
     </StyledContainer>

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/DataModelTree/DataModelBranch.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/DataModelTree/DataModelBranch.tsx
@@ -21,8 +21,8 @@ import {
   EditOutlined,
   FolderOpenOutlined,
 } from '@ant-design/icons';
-import { Tooltip } from 'antd';
-import { IW, ToolbarButton } from 'app/components';
+import { Button, Tooltip } from 'antd';
+import { IW } from 'app/components';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import { FC, memo, useState } from 'react';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
@@ -30,8 +30,9 @@ import styled from 'styled-components/macro';
 import {
   FONT_SIZE_BASE,
   FONT_SIZE_HEADING,
-  INFO,
-  SPACE_UNIT,
+  SPACE,
+  SPACE_MD,
+  SPACE_XS,
   YELLOW,
 } from 'styles/StyleConstants';
 import { Column } from '../../../slice/types';
@@ -40,19 +41,19 @@ import DataModelNode from './DataModelNode';
 
 const DataModelBranch: FC<{
   node: Column;
-  getPermissionButton: (name) => JSX.Element;
   onNodeTypeChange: (type: any, name: string) => void;
   onMoveToHierarchy: (node: Column) => void;
   onEditBranch;
   onDelete: (node: Column) => void;
+  onDeleteFromHierarchy: (parent: Column) => (node: Column) => void;
 }> = memo(
   ({
     node,
-    getPermissionButton,
     onNodeTypeChange,
     onMoveToHierarchy,
     onEditBranch,
     onDelete,
+    onDeleteFromHierarchy,
   }) => {
     const t = useI18NPrefix('view.model');
     const [isHover, setIsHover] = useState(false);
@@ -78,23 +79,19 @@ const DataModelBranch: FC<{
             <div className="action">
               {isHover && !isDragging && (
                 <Tooltip title={t('rename')}>
-                  <ToolbarButton
-                    size="small"
-                    iconSize={FONT_SIZE_BASE}
-                    className="suffix"
+                  <Button
+                    type="link"
                     onClick={() => onEditBranch(node)}
-                    icon={<EditOutlined style={{ color: INFO }} />}
+                    icon={<EditOutlined />}
                   />
                 </Tooltip>
               )}
               {isHover && !isDragging && (
                 <Tooltip title={t('delete')}>
-                  <ToolbarButton
-                    size="small"
-                    iconSize={FONT_SIZE_BASE}
-                    className="suffix"
+                  <Button
+                    type="link"
                     onClick={() => onDelete(node)}
-                    icon={<DeleteOutlined style={{ color: INFO }} />}
+                    icon={<DeleteOutlined />}
                   />
                 </Tooltip>
               )}
@@ -103,11 +100,12 @@ const DataModelBranch: FC<{
           <div className="children">
             {node?.children?.map(childNode => (
               <DataModelNode
+                className="in-hierarchy"
                 node={childNode}
                 key={childNode.name}
-                getPermissionButton={getPermissionButton}
                 onMoveToHierarchy={onMoveToHierarchy}
                 onNodeTypeChange={onNodeTypeChange}
+                onDeleteFromHierarchy={onDeleteFromHierarchy(node)}
               />
             ))}
           </div>
@@ -152,23 +150,23 @@ const DataModelBranch: FC<{
 export default DataModelBranch;
 
 const StyledDataModelBranch = styled.div<{}>`
-  line-height: 32px;
-  margin: ${SPACE_UNIT};
-  user-select: 'none';
+  margin: ${SPACE} ${SPACE_MD};
   font-size: ${FONT_SIZE_BASE};
+  line-height: 32px;
+  user-select: 'none';
 
   & .content {
     display: flex;
   }
 
   & .children {
-    margin-left: 40px;
+    margin-left: ${SPACE_MD};
   }
 
   & .action {
     display: flex;
     flex: 1;
     justify-content: flex-end;
-    padding-right: ${FONT_SIZE_BASE}px;
+    padding-right: ${SPACE_XS};
   }
 `;

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/DataModelTree/DataModelTree.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/DataModelTree/DataModelTree.tsx
@@ -16,36 +16,25 @@
  * limitations under the License.
  */
 
-import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
-import { Form, Input, Select, Tooltip } from 'antd';
-import { Popup, ToolbarButton, Tree } from 'app/components';
+import { Form, Input, Select } from 'antd';
 import { DataViewFieldType } from 'app/constants';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import useStateModal, { StateModalSize } from 'app/hooks/useStateModal';
 import { APP_CURRENT_VERSION } from 'app/migration/constants';
-import { selectRoles } from 'app/pages/MainPage/pages/MemberPage/slice/selectors';
-import { SubjectTypes } from 'app/pages/MainPage/pages/PermissionPage/constants';
-import classnames from 'classnames';
-import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, memo, useEffect, useMemo, useState } from 'react';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components/macro';
-import { FONT_SIZE_BASE, INFO } from 'styles/StyleConstants';
+import { SPACE_LG } from 'styles/StyleConstants';
 import { Nullable } from 'types';
 import { CloneValueDeep, isEmpty, isEmptyArray } from 'utils/object';
-import { uuidv4 } from 'utils/utils';
 import { ViewViewModelStages } from '../../../constants';
 import { useViewSlice } from '../../../slice';
 import {
   selectCurrentEditingView,
   selectCurrentEditingViewAttr,
 } from '../../../slice/selectors';
-import {
-  Column,
-  ColumnPermission,
-  ColumnRole,
-  Model,
-} from '../../../slice/types';
+import { Column, ColumnRole, Model } from '../../../slice/types';
 import { dataModelColumnSorter } from '../../../utils';
 import Container from '../Container';
 import {
@@ -62,17 +51,10 @@ const DataModelTree: FC = memo(() => {
   const { actions } = useViewSlice();
   const dispatch = useDispatch();
   const [openStateModal, contextHolder] = useStateModal({});
-  const viewId = useSelector(state =>
-    selectCurrentEditingViewAttr(state, { name: 'id' }),
-  ) as string;
   const currentEditingView = useSelector(selectCurrentEditingView);
   const stage = useSelector(state =>
     selectCurrentEditingViewAttr(state, { name: 'stage' }),
   ) as ViewViewModelStages;
-  const roles = useSelector(selectRoles);
-  const columnPermissions = useSelector(state =>
-    selectCurrentEditingViewAttr(state, { name: 'columnPermissions' }),
-  ) as ColumnPermission[];
   const [hierarchy, setHierarchy] = useState<Nullable<Model>>();
 
   useEffect(() => {
@@ -87,72 +69,13 @@ const DataModelTree: FC = memo(() => {
       .sort(dataModelColumnSorter);
   }, [hierarchy]);
 
-  const roleDropdownData = useMemo(
-    () =>
-      roles.map(({ id, name }) => ({
-        key: id,
-        title: name,
-        value: id,
-        isLeaf: true,
-      })),
-    [roles],
-  );
-
-  const checkRoleColumnPermission = useCallback(
-    columnName => checkedKeys => {
-      const fullPermissions = Object.keys(hierarchy || {});
-      dispatch(
-        actions.changeCurrentEditingView({
-          columnPermissions: roleDropdownData.reduce<ColumnPermission[]>(
-            (updated, { key }) => {
-              const permission = columnPermissions.find(
-                ({ subjectId }) => subjectId === key,
-              );
-              const checkOnCurrentRole = checkedKeys.includes(key);
-              if (permission) {
-                if (checkOnCurrentRole) {
-                  const updatedColumnPermission = Array.from(
-                    new Set(permission.columnPermission.concat(columnName)),
-                  );
-                  return fullPermissions.sort().join(',') !==
-                    updatedColumnPermission.sort().join(',')
-                    ? updated.concat({
-                        ...permission,
-                        columnPermission: updatedColumnPermission,
-                      })
-                    : updated;
-                } else {
-                  return updated.concat({
-                    ...permission,
-                    columnPermission: permission.columnPermission.filter(
-                      c => c !== columnName,
-                    ),
-                  });
-                }
-              } else {
-                return !checkOnCurrentRole
-                  ? updated.concat({
-                      id: uuidv4(),
-                      viewId,
-                      subjectId: key,
-                      subjectType: SubjectTypes.Role,
-                      columnPermission: fullPermissions.filter(
-                        c => c !== columnName,
-                      ),
-                    })
-                  : updated;
-              }
-            },
-            [],
-          ),
-        }),
-      );
-    },
-    [dispatch, actions, viewId, hierarchy, columnPermissions, roleDropdownData],
-  );
-
   const handleDeleteBranch = (node: Column) => {
     const newHierarchy = deleteBranch(tableColumns, node);
+    handleDataModelHierarchyChange(newHierarchy);
+  };
+
+  const handleDeleteFromBranch = (parent: Column) => (node: Column) => {
+    const newHierarchy = deleteFromBranch(tableColumns, parent, node);
     handleDataModelHierarchyChange(newHierarchy);
   };
 
@@ -290,7 +213,7 @@ const DataModelTree: FC = memo(() => {
           return c.name;
         });
         return (
-          <Form.Item
+          <StyledFormItem
             label={t('model.hierarchyName')}
             name="hierarchyName"
             rules={[
@@ -306,7 +229,7 @@ const DataModelTree: FC = memo(() => {
             ]}
           >
             <Input onChange={e => onChangeEvent(e.target?.value)} />
-          </Form.Item>
+          </StyledFormItem>
         );
       },
     });
@@ -335,7 +258,7 @@ const DataModelTree: FC = memo(() => {
       },
       content: onChangeEvent => {
         return (
-          <Form.Item
+          <StyledFormItem
             label={t('model.hierarchyName')}
             name="hierarchyName"
             rules={[{ required: true }]}
@@ -345,7 +268,7 @@ const DataModelTree: FC = memo(() => {
                 <Select.Option value={n.name}>{n.name}</Select.Option>
               ))}
             </Select>
-          </Form.Item>
+          </StyledFormItem>
         );
       },
     });
@@ -377,7 +300,7 @@ const DataModelTree: FC = memo(() => {
       },
       content: onChangeEvent => {
         return (
-          <Form.Item
+          <StyledFormItem
             label={t('model.rename')}
             initialValue={node?.name}
             name="rename"
@@ -398,7 +321,7 @@ const DataModelTree: FC = memo(() => {
                 onChangeEvent(e.target?.value);
               }}
             />
-          </Form.Item>
+          </StyledFormItem>
         );
       },
     });
@@ -476,6 +399,20 @@ const DataModelTree: FC = memo(() => {
     }
   };
 
+  const deleteFromBranch = (
+    columns: Column[],
+    parent: Column,
+    node: Column,
+  ) => {
+    const branchNode = columns.find(c => c.name === parent.name);
+    if (branchNode) {
+      branchNode.children = branchNode.children?.filter(
+        c => c.name !== node.name,
+      );
+      return toModel(columns, node);
+    }
+  };
+
   const moveNode = (
     columns: Column[],
     node: Column,
@@ -506,69 +443,8 @@ const DataModelTree: FC = memo(() => {
     );
   };
 
-  const getPermissionButton = useCallback(
-    (name: string) => {
-      // 没有记录相当于对所有字段都有权限
-      const checkedKeys =
-        columnPermissions.length > 0
-          ? roleDropdownData.reduce<string[]>((selected, { key }) => {
-              const permission = columnPermissions.find(
-                ({ subjectId }) => subjectId === key,
-              );
-              if (permission) {
-                return permission.columnPermission.includes(name)
-                  ? selected.concat(key)
-                  : selected;
-              } else {
-                return selected.concat(key);
-              }
-            }, [])
-          : roleDropdownData.map(({ key }) => key);
-
-      return (
-        <Popup
-          key={`${name}_columnpermission`}
-          trigger={['click']}
-          placement="bottomRight"
-          content={
-            <Tree
-              className="dropdown"
-              treeData={roleDropdownData}
-              checkedKeys={checkedKeys}
-              loading={false}
-              selectable={false}
-              onCheck={checkRoleColumnPermission(name)}
-              blockNode
-              checkable
-            />
-          }
-        >
-          <Tooltip title={t('columnPermission.title')}>
-            <ToolbarButton
-              size="small"
-              iconSize={FONT_SIZE_BASE}
-              icon={
-                checkedKeys.length > 0 ? (
-                  <EyeOutlined
-                    style={{ color: INFO }}
-                    className={classnames({
-                      partial: checkedKeys.length !== roleDropdownData.length,
-                    })}
-                  />
-                ) : (
-                  <EyeInvisibleOutlined />
-                )
-              }
-            />
-          </Tooltip>
-        </Popup>
-      );
-    },
-    [columnPermissions, roleDropdownData, checkRoleColumnPermission, t],
-  );
-
   return (
-    <Container title="model" isLoading={stage === ViewViewModelStages.Running}>
+    <Container title="model" loading={stage === ViewViewModelStages.Running}>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable
           droppableId={ROOT_CONTAINER_ID}
@@ -585,17 +461,16 @@ const DataModelTree: FC = memo(() => {
                   <DataModelBranch
                     node={col}
                     key={col.name}
-                    getPermissionButton={getPermissionButton}
                     onNodeTypeChange={handleNodeTypeChange}
                     onMoveToHierarchy={openMoveToHierarchyModal}
                     onEditBranch={openEditBranchModal}
                     onDelete={handleDeleteBranch}
+                    onDeleteFromHierarchy={handleDeleteFromBranch}
                   />
                 ) : (
                   <DataModelNode
                     node={col}
                     key={col.name}
-                    getPermissionButton={getPermissionButton}
                     onCreateHierarchy={openCreateHierarchyModal}
                     onNodeTypeChange={handleNodeTypeChange}
                     onMoveToHierarchy={openMoveToHierarchyModal}
@@ -616,4 +491,8 @@ export default DataModelTree;
 
 const StyledDroppableContainer = styled.div<{ isDraggingOver }>`
   user-select: 'none';
+`;
+
+const StyledFormItem = styled(Form.Item)`
+  margin: ${SPACE_LG} 0 0 0;
 `;


### PR DESCRIPTION
- 移除了列权限设置按钮
- 将类型与分类设置按钮放到了字段头部的图标上
- 给模型层级中的字段添加了独立删除按钮
- 样式优化

![image](https://user-images.githubusercontent.com/4098913/164415022-5de3f476-f69d-4b0b-8108-74568b40dee1.png)
