### PR TITLE
hotfix: getRuntimeDateLevelFields for task function

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/utils/index.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/index.ts
@@ -319,7 +319,6 @@ export const getControllerDateValues = (obj: {
       const isStart = !obj.execute;
       const time = getTime(+(direction + amount), unit)(unit, isStart);
       timeValues[1] = time.format(TIME_FORMATTER);
-      debugger;
     }
   }
 

--- a/frontend/src/app/utils/chartHelper.ts
+++ b/frontend/src/app/utils/chartHelper.ts
@@ -1588,7 +1588,7 @@ export const getChartsAllRows = (configs?: ChartDataConfig[]) => {
 
 export const getRuntimeDateLevelFields = (rows: any) => {
   const _rows = CloneValueDeep(rows);
-  _rows.forEach((v, i) => {
+  _rows?.forEach((v, i) => {
     const symbolData = v?.[RUNTIME_DATE_LEVEL_KEY];
     if (symbolData) {
       _rows[i] = symbolData;

--- a/frontend/src/app/utils/chartHelper.ts
+++ b/frontend/src/app/utils/chartHelper.ts
@@ -1587,13 +1587,12 @@ export const getChartsAllRows = (configs?: ChartDataConfig[]) => {
 };
 
 export const getRuntimeDateLevelFields = (rows: any) => {
-  const _rows = updateBy(rows, draft => {
-    draft?.forEach((v, i) => {
-      const symbolData = v?.[RUNTIME_DATE_LEVEL_KEY];
-      if (symbolData) {
-        draft[i] = symbolData;
-      }
-    });
+  const _rows = CloneValueDeep(rows);
+  _rows.forEach((v, i) => {
+    const symbolData = v?.[RUNTIME_DATE_LEVEL_KEY];
+    if (symbolData) {
+      _rows[i] = symbolData;
+    }
   });
   return _rows;
 };


### PR DESCRIPTION
调用链   task  ->   ChartDataRequestBuilder   ->  getRuntimeDateLevelFields  -> updateBy -> immer 

导致 task build出来的 代码 包含immer和process.env 相关代码后端无法执行。

方案1
这里我改了 getRuntimeDateLevelFields 里面的代码 把updateBy 去掉了 CloneValueDeep 代替 。最终build出来的task代码就不包含 immer和process.env 。

方案2 
当然 也可以 直接在 ChartDataRequestBuilder 里面不去使用 getRuntimeDateLevelFields。在ChartDataRequestBuilder 自己实现getRuntimeDateLevelFields 的相关逻辑转换而不使用 updateBy 。