### PR TITLE
解决了postgresql连接类型查询时不支持分页的问题

### DIFF
--- a/data-providers/jdbc-data-provider/src/main/resources/jdbc-driver.yml
+++ b/data-providers/jdbc-data-provider/src/main/resources/jdbc-driver.yml
@@ -145,6 +145,7 @@ POSTGRESQL:
   name: POSTGRESQL
   driver-class: org.postgresql.Driver
   url-prefix: jdbc:postgresql://
+  sql-dialect: datart.data.provider.calcite.dialect.PostgresqlSqlDialectSupport
 
 PRESTO:
   db-type: PRESTO

--- a/data-providers/src/main/java/datart/data/provider/calcite/dialect/PostgresqlSqlDialectSupport.java
+++ b/data-providers/src/main/java/datart/data/provider/calcite/dialect/PostgresqlSqlDialectSupport.java
@@ -1,0 +1,12 @@
+package datart.data.provider.calcite.dialect;
+
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+
+public class PostgresqlSqlDialectSupport extends PostgresqlSqlDialect implements FetchAndOffsetSupport{
+
+    public PostgresqlSqlDialectSupport() {
+        this(DEFAULT_CONTEXT);
+    }
+    private PostgresqlSqlDialectSupport(Context context) { super(context); }
+
+}


### PR DESCRIPTION
增加了postgresql的SqlDialect类，实现了FetchAndOffsetSupport接口，修改了对应的配置文件。使postgresql支持分页。解决了查询时拉取全量数据至本地的问题。