### PR TITLE
fix: object key

### DIFF
--- a/frontend/src/app/components/FormGenerator/utils.ts
+++ b/frontend/src/app/components/FormGenerator/utils.ts
@@ -81,7 +81,7 @@ export function removeSomeObjectConfigByKey(
       } else {
         return {
           ...data,
-          key: obj?.[key],
+          [key]: obj?.[key],
         };
       }
     }, {})

--- a/frontend/src/app/components/FormGenerator/utils.ts
+++ b/frontend/src/app/components/FormGenerator/utils.ts
@@ -76,14 +76,10 @@ export function removeSomeObjectConfigByKey(
   return (
     obj &&
     Object.keys(obj).reduce((data, key) => {
-      if (removeKeyList.includes(key)) {
-        return data;
-      } else {
-        return {
-          ...data,
-          [key]: obj?.[key],
-        };
+      if (!removeKeyList.includes(key)) {
+        data[key] = obj[key];
       }
+      return data;
     }, {})
   );
 }


### PR DESCRIPTION
removeSomeObjectConfigByKey 对 options 错误的转换导致下拉框多选失效

```
        {
          label: 'style.autoMergeFields',
          key: 'autoMergeFields',
          comType: 'select',
          options: {
            mode: 'multiple',
            ...
```

![image](https://user-images.githubusercontent.com/31752986/168421823-0c715bd3-0a89-4eee-a827-77cecd25c237.png)
