### PR TITLE
fix: chart sorter

### DIFF
--- a/frontend/src/app/models/ChartDataRequestBuilder.ts
+++ b/frontend/src/app/models/ChartDataRequestBuilder.ts
@@ -346,22 +346,13 @@ export class ChartDataRequestBuilder {
       aggOperator: aggCol.aggregate,
     }));
 
-    return originalSorters
-      .reduce<ChartDataRequest['orders']>((acc, cur) => {
-        const uniqSorter = sorter =>
-          `${sorter.column}-${
-            sorter.aggOperator?.length > 0 ? sorter.aggOperator : ''
-          }`;
-        const newSorter = this.extraSorters?.find(
-          extraSorter => uniqSorter(extraSorter) === uniqSorter(cur),
-        );
-        if (newSorter) {
-          return acc;
-        }
-        return acc.concat([cur]);
-      }, [])
-      .concat(this.extraSorters as [])
-      .filter(sorter => Boolean(sorter?.operator));
+    const _extraSorters = this.extraSorters?.filter(
+      ({ column, operator }) => column && operator,
+    );
+    if (_extraSorters.length) {
+      return _extraSorters;
+    }
+    return originalSorters.filter(sorter => Boolean(sorter?.operator));
   }
 
   private buildPageInfo() {

--- a/frontend/src/app/models/ChartDataRequestBuilder.ts
+++ b/frontend/src/app/models/ChartDataRequestBuilder.ts
@@ -349,7 +349,7 @@ export class ChartDataRequestBuilder {
     const _extraSorters = this.extraSorters?.filter(
       ({ column, operator }) => column && operator,
     );
-    if (_extraSorters.length) {
+    if (!isEmptyArray(_extraSorters)) {
       return _extraSorters;
     }
     return originalSorters.filter(sorter => Boolean(sorter?.operator));

--- a/frontend/src/app/models/__tests__/ChartDataRequestBuilder.test.ts
+++ b/frontend/src/app/models/__tests__/ChartDataRequestBuilder.test.ts
@@ -798,9 +798,6 @@ describe('ChartDataRequestBuild Test', () => {
     const requestParams = builder.build();
 
     expect(requestParams.orders).toEqual([
-      { column: 'first-name', operator: 'ASC', aggOperator: undefined },
-      { column: 'last-name', operator: 'DESC', aggOperator: undefined },
-      { column: 'address', operator: 'DESC', aggOperator: undefined },
       {
         column: 'age',
         aggOperator: 'AVG',
@@ -813,9 +810,6 @@ describe('ChartDataRequestBuild Test', () => {
     builder.addExtraSorters(extraSorters2);
 
     expect(requestParams.orders).toEqual([
-      { column: 'first-name', operator: 'ASC', aggOperator: undefined },
-      { column: 'last-name', operator: 'DESC', aggOperator: undefined },
-      { column: 'address', operator: 'DESC', aggOperator: undefined },
       {
         column: 'age',
         aggOperator: 'AVG',


### PR DESCRIPTION
基本保留现有实现，只改一条：在预览页面用户运行时操作某一列排序时、预设的排序条件失效，仅该列排序条件生效；当运行时排序取消时，预设条件生效。