### PR TITLE
fix:  field no auto aggregation

### DIFF
--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/ChartDraggableTargetContainer.tsx
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/ChartDraggableTargetContainer.tsx
@@ -101,7 +101,7 @@ export const ChartDraggableTargetContainer: FC<ChartDataConfigSectionProps> =
                 let config: ChartDataSectionField = {
                   uid: uuidv4(),
                   ...val,
-                  aggregate: getDefaultAggregate(val),
+                  aggregate: getDefaultAggregate(val, currentConfig),
                 };
                 if (
                   val.category ===
@@ -128,7 +128,7 @@ export const ChartDraggableTargetContainer: FC<ChartDataConfigSectionProps> =
               hierarchyChildFields.map(val => ({
                 uid: uuidv4(),
                 ...val,
-                aggregate: getDefaultAggregate(val),
+                aggregate: getDefaultAggregate(val, currentConfig),
               })),
             );
             updateCurrentConfigColumns(currentConfig, currentColumns, true);
@@ -146,7 +146,7 @@ export const ChartDraggableTargetContainer: FC<ChartDataConfigSectionProps> =
                 currentConfig?.rows || [],
                 draft => {
                   draft.splice(originItemIndex, 1);
-                  item.aggregate = getDefaultAggregate(item);
+                  item.aggregate = getDefaultAggregate(item, currentConfig);
                   return draft.splice(item?.index!, 0, item);
                 },
               );
@@ -159,7 +159,7 @@ export const ChartDraggableTargetContainer: FC<ChartDataConfigSectionProps> =
               const currentColumns = updateBy(
                 currentConfig?.rows || [],
                 draft => {
-                  item.aggregate = getDefaultAggregate(item);
+                  item.aggregate = getDefaultAggregate(item, currentConfig);
                   return draft.splice(item?.index!, 0, item);
                 },
               );

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/utils.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/utils.ts
@@ -46,7 +46,7 @@ export const updateDataConfigByField = (
 };
 export const getDefaultAggregate = (
   item: ChartDataSectionField,
-  config?: ChartDataConfig,
+  config: ChartDataConfig,
 ) => {
   if (
     config?.type === ChartDataSectionType.Aggregate ||


### PR DESCRIPTION
ChartDraggableTargetContainer.tsx file does not pass currentConfig parameter when calling getDefaultAggregate