### PR TITLE
修复定时任务模块，当先点击运行中的任务，再点击新建任务，右上方的保存按钮依旧是禁用状态；已修复为新建任务时初始化active的状态为false

### DIFF
--- a/frontend/src/app/pages/MainPage/pages/SchedulePage/EditorPage/index.tsx
+++ b/frontend/src/app/pages/MainPage/pages/SchedulePage/EditorPage/index.tsx
@@ -73,8 +73,8 @@ export const EditorPage: FC = () => {
     return scheduleId === 'add';
   }, [scheduleId]);
   const active = useMemo(() => {
-    return editingSchedule?.active;
-  }, [editingSchedule]);
+    return isAdd ? false : editingSchedule?.active;
+  }, [editingSchedule, isAdd]);
   const refreshScheduleList = useCallback(() => {
     dispatch(getSchedules(orgId));
   }, [dispatch, orgId]);


### PR DESCRIPTION
问题描述：定时任务模块，当先点击运行中状态的任务（此状态保存按钮为禁用状态），再点击新建任务，右上方保存按钮依旧为禁用状态，不合理，正常新增任务是支持保存操作的；
修复方式：当新建任务时，根据isAdd值，初始化active的值，具体代码如下：
 const active = useMemo(() => {
    return isAdd ? false : editingSchedule?.active;
  }, [editingSchedule, isAdd]);