### PR TITLE
fix: Add default value to dataset when there is no view id

### DIFF
--- a/frontend/src/app/pages/MainPage/pages/VizPage/slice/thunks.ts
+++ b/frontend/src/app/pages/MainPage/pages/VizPage/slice/thunks.ts
@@ -366,7 +366,7 @@ export const fetchDataSetByPreviewChartAction = createAsyncThunk(
     if (!currentChartPreview?.backendChart?.view.id) {
       return {
         backendChartId: currentChartPreview?.backendChartId,
-        data: currentChartPreview?.backendChart?.config.sampleData,
+        data: currentChartPreview?.backendChart?.config.sampleData || [],
       };
     }
     const builder = new ChartDataRequestBuilder(


### PR DESCRIPTION
fix: Add default value to dataset when there is no view id