### PR TITLE
fix: 数据视图-变量配置-搜索功能、数据视图-设置-有效期不能为负值

### DIFF
--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
@@ -310,7 +310,7 @@ export const Variables = memo(() => {
       },
       onSearch: debouncedSearch,
     }),
-    [showAddForm, t],
+    [showAddForm, t, debouncedSearch],
   );
 
   return (

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
@@ -26,6 +26,7 @@ import {
 } from '@ant-design/icons';
 import { Button, List, Popconfirm } from 'antd';
 import { ListItem } from 'app/components';
+import { useDebouncedSearch } from 'app/hooks/useDebouncedSearch';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import { getRoles } from 'app/pages/MainPage/pages/MemberPage/slice/thunks';
 import {
@@ -68,7 +69,6 @@ import { getEditorProvideCompletionItems } from '../../slice/thunks';
 import { VariableHierarchy } from '../../slice/types';
 import { comparePermissionChange } from '../../utils';
 import Container from './Container';
-import { useDebouncedSearch } from 'app/hooks/useDebouncedSearch';
 
 export const Variables = memo(() => {
   const { actions } = useViewSlice();
@@ -293,10 +293,11 @@ export const Variables = memo(() => {
     [variables, publicVariables, t],
   );
 
-  const { filteredData, debouncedSearch } = useDebouncedSearch(listSource,
+  const { filteredData, debouncedSearch } = useDebouncedSearch(
+    listSource,
     (keywords, data) => {
-      return data.name.includes(keywords)
-    }
+      return data.name.includes(keywords);
+    },
   );
 
   const titleProps = useMemo(
@@ -307,7 +308,7 @@ export const Variables = memo(() => {
         items: [{ key: 'variable', text: t('add') }],
         callback: showAddForm,
       },
-      onSearch: debouncedSearch
+      onSearch: debouncedSearch,
     }),
     [showAddForm, t],
   );

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/Main/Properties/Variables.tsx
@@ -68,6 +68,7 @@ import { getEditorProvideCompletionItems } from '../../slice/thunks';
 import { VariableHierarchy } from '../../slice/types';
 import { comparePermissionChange } from '../../utils';
 import Container from './Container';
+import { useDebouncedSearch } from 'app/hooks/useDebouncedSearch';
 
 export const Variables = memo(() => {
   const { actions } = useViewSlice();
@@ -292,6 +293,12 @@ export const Variables = memo(() => {
     [variables, publicVariables, t],
   );
 
+  const { filteredData, debouncedSearch } = useDebouncedSearch(listSource,
+    (keywords, data) => {
+      return data.name.includes(keywords)
+    }
+  );
+
   const titleProps = useMemo(
     () => ({
       title: 'variable',
@@ -300,6 +307,7 @@ export const Variables = memo(() => {
         items: [{ key: 'variable', text: t('add') }],
         callback: showAddForm,
       },
+      onSearch: debouncedSearch
     }),
     [showAddForm, t],
   );
@@ -308,7 +316,7 @@ export const Variables = memo(() => {
     <Container {...titleProps}>
       <ListWrapper>
         <List
-          dataSource={listSource}
+          dataSource={filteredData}
           loading={
             stage === ViewViewModelStages.Loading && {
               indicator: <LoadingOutlined />,

--- a/frontend/src/app/pages/MainPage/pages/ViewPage/SaveForm.tsx
+++ b/frontend/src/app/pages/MainPage/pages/ViewPage/SaveForm.tsx
@@ -234,7 +234,7 @@ export function SaveForm({ formProps, ...modalProps }: SaveFormProps) {
               label={t('cacheExpires')}
               initialValue={0}
             >
-              <InputNumber disabled={!cache} />
+              <InputNumber disabled={!cache} min={0} />
             </Form.Item>
             <Form.Item
               wrapperCol={{ span: 13, offset: 9 }}


### PR DESCRIPTION
![bugsearchQQ截图20220720220131](https://user-images.githubusercontent.com/13906201/180001732-513d46cc-d390-4a8b-8cc3-22de686ef651.png)
![input-rule-QQ截图20220720221635](https://user-images.githubusercontent.com/13906201/180006809-f88a0ca1-4daa-4f9b-94bf-d3c3c90b5eab.png)

另外，右边这几个面板的搜索功能都没有忽略大小写，我感觉忽略大小写用起来更方便，可以改吗，可以的话我明天改好再提个pr