### PR TITLE
fix: 饼图、环形图，标签位置选“中心”时不显示

### DIFF
--- a/frontend/src/app/components/ChartGraph/BasicPieChart/BasicPieChart.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicPieChart/BasicPieChart.tsx
@@ -24,6 +24,7 @@ import {
   ChartConfig,
   ChartDataSectionField,
   ChartStyleConfig,
+  EmphasisStyle,
   LabelStyle,
   LegendStyle,
   SelectedItem,
@@ -339,6 +340,8 @@ class BasicPieChart extends Chart {
       ['showLabel', 'position', 'font'],
     );
     const formatter = this.getLabelFormatter(styles);
+    const emphasisStyle = this.getEmphasisStyle(styles);
+
     return {
       label: {
         show: position === 'center' ? false : show,
@@ -347,6 +350,7 @@ class BasicPieChart extends Chart {
         formatter,
       },
       labelLayout: { hideOverlap: true },
+      emphasis: emphasisStyle,
     };
   }
 
@@ -388,6 +392,24 @@ class BasicPieChart extends Chart {
           : ''
       }`;
     };
+  }
+
+  private getEmphasisStyle(styles: ChartStyleConfig[]): EmphasisStyle {
+    const [show, position, font] = getStyles(
+      styles,
+      ['label'],
+      ['showLabel', 'position', 'font'],
+    );
+    const needEmphasisStyle = position === 'center' && show;
+    const emphasisStyle = needEmphasisStyle
+      ? {
+          label: {
+            show: true,
+            ...font,
+          },
+        }
+      : {};
+    return emphasisStyle;
   }
 
   private getSeriesStyle(styles: ChartStyleConfig[]): PieSeries {

--- a/frontend/src/app/types/ChartConfig.ts
+++ b/frontend/src/app/types/ChartConfig.ts
@@ -322,6 +322,13 @@ export type AxisLabel = {
   font?: FontStyle;
 } & FontStyle;
 
+export type EmphasisStyle = {
+  label?: {
+    show?: boolean;
+    font?: FontStyle;
+  };
+};
+
 export type LabelStyle = {
   label?: {
     position?: string;
@@ -330,6 +337,7 @@ export type LabelStyle = {
     formatter?: string | ((params) => string);
   } & FontStyle;
   labelLayout?: { hideOverlap: boolean };
+  emphasis?: EmphasisStyle;
 };
 
 export interface LegendStyle {

--- a/frontend/src/app/types/ChartConfig.ts
+++ b/frontend/src/app/types/ChartConfig.ts
@@ -325,8 +325,7 @@ export type AxisLabel = {
 export type EmphasisStyle = {
   label?: {
     show?: boolean;
-    font?: FontStyle;
-  };
+  } & FontStyle;
 };
 
 export type LabelStyle = {


### PR DESCRIPTION
![label-center-QQ截图20220721224638](https://user-images.githubusercontent.com/13906201/180243573-065bf5a2-e00f-4ff9-a5d7-2f6305f6ac6d.png)
![label-center-QQ截图20220721224706](https://user-images.githubusercontent.com/13906201/180243595-6717aa37-e557-4623-8680-7a6cbdfb9bce.png)

参考这个页面写的：https://echarts.apache.org/examples/zh/editor.html?c=pie-doughnut
鼠标移到一个色块上才能显示。
#1080 