### PR TITLE
fix: get user info not set name and description

### DIFF
--- a/server/src/main/java/datart/server/base/dto/UserProfile.java
+++ b/server/src/main/java/datart/server/base/dto/UserProfile.java
@@ -22,10 +22,12 @@ package datart.server.base.dto;
 import datart.core.entity.User;
 import datart.core.entity.ext.UserBaseInfo;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class UserProfile extends UserBaseInfo {
 
     private String name;
@@ -36,5 +38,7 @@ public class UserProfile extends UserBaseInfo {
     
     public UserProfile(User user) {
         super(user);
+        this.name = user.getName();
+        this.description = user.getDescription();
     }
 }


### PR DESCRIPTION
我发现获取用户信息的时候，没设置name 和 description，导致前端展示不了名称，对应这个issues类似的，展示不了名称 https://github.com/running-elephant/datart/issues/1537  