### PR TITLE
fix: import resource problem, when dashboard contain relation

### DIFF
--- a/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
@@ -518,8 +518,8 @@ public class DashboardServiceImpl extends BaseService implements DashboardServic
             final Map<String, String> widgetIdMapping = new HashMap<>();
             for (WidgetDetail widget : mainModel.getWidgets()) {
                 String widgetId = UUIDGenerator.generate();
-                widget.setId(widgetId);
                 widgetIdMapping.put(widget.getId(), widgetId);
+                widget.setId(widgetId);
             }
             for (WidgetDetail widget : mainModel.getWidgets()) {
                 widget.setDashboardId(newId);
@@ -537,6 +537,7 @@ public class DashboardServiceImpl extends BaseService implements DashboardServic
                 }
                 if (widget.getRelations() != null) {
                     for (RelWidgetWidget relation : widget.getRelations()) {
+                        relation.setId(UUIDGenerator.generate());
                         relation.setSourceId(widgetIdMapping.get(relation.getSourceId()));
                         relation.setTargetId(widgetIdMapping.get(relation.getTargetId()));
                     }


### PR DESCRIPTION
修复资源迁移-》数据导入的问题，当dashboard页面中包含 联动组件（两个组件相互关联）的时候，导出该dashboard资源后，再导入到其他的组织的时候会报错

例如在demo环境，导出导入这个页面就会报错 
http://datart-demo.retech.cc/organizations/b82a1357face4342b678070ab170fe84/vizs/91df22a74354423998168c6da4b7f35a

报错信息如下：

![image](https://user-images.githubusercontent.com/22886101/182850815-2a454566-91f4-41ef-90cc-15888feed6c9.png)

n### Error updating database.  Cause: java.sql.SQLIntegrityConstraintViolationException: Column 'source_id' cannot be null


我看到的设置导入 资源，存储新旧widget的id的时候，顺序不对，需要修改先保留新旧widget id，再设置原widget对象的


另外 ralation 对象的id，如果之前导入过一次，然后策略还是选择新增的时候，这里的relation id就要设置重新设置，不然再次导入相同资源，策略为新增的时候也会报错


麻烦大佬帮忙code review一下提交的pr代码是否有问题了
