### PR TITLE
修复view 中解析配置的schema，columns -》 name的问题

### DIFF
--- a/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
@@ -440,13 +440,9 @@ public class DataProviderServiceImpl extends BaseService implements DataProvider
                 jsonObject = jsonObject.getJSONObject("columns");
                 for (String key : jsonObject.keySet()) {
                     JSONObject item = jsonObject.getJSONObject(key);
-                    String nameString = item.getJSONArray("name").getString(0);
-                    String[] names;
-                    try {
-                        names = JSONObject.parseArray(nameString).toArray(new String[0]);
-                    } catch (JSONException e) {
-                        names = new String[]{nameString};
-                    }
+                    String[] names = item.get("name") instanceof JSONArray
+                            ? item.getJSONArray("name").stream().toArray(String[]::new)
+                            : new String[]{item.get("name").toString()};
                     Column column = Column.of(ValueType.valueOf(item.getString("type")), names);
                     schema.put(column.columnKey(), column);
                 }


### PR DESCRIPTION
我发现在1.0.0-beta.3中，保存view的时候，列的信息中   columns -》 name 的值是字符串来的，但是到了1.0.0-beta.4 中 columns -》 name 的值是数组来的，然后这部分DataProviderServiceImpl#parseSchema  在 1.0.0-beta.4 版本去执行之前 版本所保存的view，关联的datachart图就会报解析错误了，因为之前的代码解析是默认将name当做数组解析了，所以导致name为字符串的时候就报错了。


我修改的代码就是判断一下类型，是数组的才用数组解析，否则都获取字符串对象


具体的报错信息如下：
```
ERROR datart.server.service.impl.DataProviderServiceImpl : view model parse error
com.alibaba.fastjson.JSONException: syntax error, pos 1, line 1, column 2dt
at com.alibaba.fastjson.parser.DefaultJSONParser.parse(DefaultJSONParser.java:1487)
at com.alibaba.fastjson.parser.DefaultJSONParser.parse(DefaultJSONParser.java:1373)
```

目前这个影响的主要是解析parseSchema 这里，应该不影响界面功能，不过好像聚合那里用到schema，可能会影响聚合


麻烦大佬有空的时候，帮忙code review一下代码了