### PR TITLE
fix: 修复#1826 issue, ldap/oauth2认证自动注册用户时,秘钥加密两次导致鉴权失败("用户已修改密码"错误)

### DIFF
--- a/server/src/main/java/datart/server/service/UserService.java
+++ b/server/src/main/java/datart/server/service/UserService.java
@@ -45,6 +45,8 @@ public interface UserService extends BaseCRUDService<User, UserMapperExt> {
 
     boolean register(UserRegisterParam user,boolean sendMail) throws MessagingException, UnsupportedEncodingException;
 
+    boolean register(UserRegisterParam user,boolean sendMail,boolean third) throws MessagingException, UnsupportedEncodingException;
+
     String activeUser(String activeString);
 
     boolean sendActiveMail(String usernameOrEmail) throws UnsupportedEncodingException, MessagingException;

--- a/server/src/main/java/datart/server/service/UserService.java
+++ b/server/src/main/java/datart/server/service/UserService.java
@@ -45,8 +45,6 @@ public interface UserService extends BaseCRUDService<User, UserMapperExt> {
 
     boolean register(UserRegisterParam user,boolean sendMail) throws MessagingException, UnsupportedEncodingException;
 
-    boolean register(UserRegisterParam user,boolean sendMail,boolean third) throws MessagingException, UnsupportedEncodingException;
-
     String activeUser(String activeString);
 
     boolean sendActiveMail(String usernameOrEmail) throws UnsupportedEncodingException, MessagingException;

--- a/server/src/main/java/datart/server/service/impl/ExternalRegisterServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/ExternalRegisterServiceImpl.java
@@ -101,7 +101,7 @@ public class ExternalRegisterServiceImpl implements ExternalRegisterService {
         registerParam.setPassword(BCrypt.hashpw(RandomStringUtils.randomAscii(32), BCrypt.gensalt()));
         registerParam.setEmail(email);
 
-        if (userService.register(registerParam, false)) {
+        if (userService.register(registerParam, false, true)) {
             PasswordToken passwordToken = new PasswordToken(registerParam.getUsername(),
                     registerParam.getPassword(),
                     System.currentTimeMillis());
@@ -131,7 +131,7 @@ public class ExternalRegisterServiceImpl implements ExternalRegisterService {
         if (emailMapping != null) {
             userRegisterParam.setEmail(JsonPath.read(jsonObj, emailMapping));
         }
-        if (userService.register(userRegisterParam, false)) {
+        if (userService.register(userRegisterParam, false, true)) {
             PasswordToken passwordToken = new PasswordToken(userRegisterParam.getUsername(),
                     userRegisterParam.getPassword(),
                     System.currentTimeMillis());

--- a/server/src/main/java/datart/server/service/impl/ExternalRegisterServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/ExternalRegisterServiceImpl.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.query.LdapQueryBuilder;
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -98,14 +97,14 @@ public class ExternalRegisterServiceImpl implements ExternalRegisterService {
 
         UserRegisterParam registerParam = new UserRegisterParam();
         registerParam.setUsername(filter);
-        registerParam.setPassword(BCrypt.hashpw(RandomStringUtils.randomAscii(32), BCrypt.gensalt()));
+        registerParam.setPassword(RandomStringUtils.randomAscii(32));
         registerParam.setEmail(email);
 
-        if (userService.register(registerParam, false, true)) {
+        if (userService.register(registerParam, false)) {
             PasswordToken passwordToken = new PasswordToken(registerParam.getUsername(),
                     registerParam.getPassword(),
                     System.currentTimeMillis());
-            return JwtUtils.toJwtString(passwordToken);
+            return userService.login(passwordToken);
         }
         return null;
     }
@@ -127,15 +126,15 @@ public class ExternalRegisterServiceImpl implements ExternalRegisterService {
 
         UserRegisterParam userRegisterParam = new UserRegisterParam();
         userRegisterParam.setUsername(oauthUser.getName());
-        userRegisterParam.setPassword(BCrypt.hashpw(RandomStringUtils.randomAscii(32), BCrypt.gensalt()));
+        userRegisterParam.setPassword(RandomStringUtils.randomAscii(32));
         if (emailMapping != null) {
             userRegisterParam.setEmail(JsonPath.read(jsonObj, emailMapping));
         }
-        if (userService.register(userRegisterParam, false, true)) {
+        if (userService.register(userRegisterParam, false)) {
             PasswordToken passwordToken = new PasswordToken(userRegisterParam.getUsername(),
                     userRegisterParam.getPassword(),
                     System.currentTimeMillis());
-            return JwtUtils.toJwtString(passwordToken);
+            return userService.login(passwordToken);
         }
         return null;
 

--- a/server/src/main/java/datart/server/service/impl/UserServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/UserServiceImpl.java
@@ -143,11 +143,6 @@ public class UserServiceImpl extends BaseService implements UserService {
     @Override
     @Transactional
     public boolean register(UserRegisterParam userRegisterParam, boolean sendMail) throws MessagingException, UnsupportedEncodingException {
-        return register(userRegisterParam, sendMail, false);
-    }
-
-    @Override
-    public boolean register(UserRegisterParam userRegisterParam, boolean sendMail, boolean third) throws MessagingException, UnsupportedEncodingException {
         if (!checkUserName(userRegisterParam.getUsername())) {
             log.error("The username({}) has been registered", userRegisterParam.getUsername());
             Exceptions.tr(ParamException.class, "error.param.occupied", "resource.user.username");
@@ -158,7 +153,7 @@ public class UserServiceImpl extends BaseService implements UserService {
         }
         User user = new User();
         BeanUtils.copyProperties(userRegisterParam, user);
-        user.setPassword(third ? userRegisterParam.getPassword() : BCrypt.hashpw(user.getPassword(), BCrypt.gensalt()));
+        user.setPassword(BCrypt.hashpw(user.getPassword(), BCrypt.gensalt()));
         user.setId(UUIDGenerator.generate());
         user.setCreateBy(user.getId());
         user.setCreateTime(new Date());

--- a/server/src/main/java/datart/server/service/impl/UserServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/UserServiceImpl.java
@@ -143,6 +143,11 @@ public class UserServiceImpl extends BaseService implements UserService {
     @Override
     @Transactional
     public boolean register(UserRegisterParam userRegisterParam, boolean sendMail) throws MessagingException, UnsupportedEncodingException {
+        return register(userRegisterParam, sendMail, false);
+    }
+
+    @Override
+    public boolean register(UserRegisterParam userRegisterParam, boolean sendMail, boolean third) throws MessagingException, UnsupportedEncodingException {
         if (!checkUserName(userRegisterParam.getUsername())) {
             log.error("The username({}) has been registered", userRegisterParam.getUsername());
             Exceptions.tr(ParamException.class, "error.param.occupied", "resource.user.username");
@@ -151,10 +156,9 @@ public class UserServiceImpl extends BaseService implements UserService {
             log.info("The email({}) has been registered", userRegisterParam.getEmail());
             Exceptions.tr(ParamException.class, "error.param.occupied", "resource.user.email");
         }
-        BCrypt.hashpw(userRegisterParam.getPassword(), BCrypt.gensalt());
         User user = new User();
         BeanUtils.copyProperties(userRegisterParam, user);
-        user.setPassword(BCrypt.hashpw(user.getPassword(), BCrypt.gensalt()));
+        user.setPassword(third ? userRegisterParam.getPassword() : BCrypt.hashpw(user.getPassword(), BCrypt.gensalt()));
         user.setId(UUIDGenerator.generate());
         user.setCreateBy(user.getId());
         user.setCreateTime(new Date());


### PR DESCRIPTION
在ldap/oauth2认证时会初始化用户密码并生成passwordToken, 然后调用注册接口, 此时注册接口会解析jwt的密码并二次加密, 这时存入数据库的密码和认证时初始化的密码不一致,导致登录时比较hashCode会抛出"用户已修改密码"错误