### PR TITLE
feat: fix parse wrong column type when parse sql for PostgreSQL(修复新建数据视图时解析数据模型字段类型不正确)

### DIFF
--- a/data-providers/data-provider-base/src/main/java/datart/data/provider/jdbc/DataTypeUtils.java
+++ b/data-providers/data-provider-base/src/main/java/datart/data/provider/jdbc/DataTypeUtils.java
@@ -17,8 +17,8 @@
  */
 package datart.data.provider.jdbc;
 
-import datart.core.base.consts.ValueType;
 import datart.core.base.consts.JavaType;
+import datart.core.base.consts.ValueType;
 import datart.data.provider.calcite.custom.CustomSqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -34,6 +34,28 @@ public class DataTypeUtils {
         SqlTypeFamily family;
         if (sqlTypeName == null) {
             family = CustomSqlTypeName.SQL_TYPE_FAMILY_MAP.getOrDefault(sqlType, CustomSqlTypeName.ANY).getFamily();
+        } else {
+            family = sqlTypeName.getFamily();
+        }
+        switch (family) {
+            case NUMERIC:
+                return ValueType.NUMERIC;
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case DATETIME:
+                return ValueType.DATE;
+            default:
+                return ValueType.STRING;
+        }
+    }
+
+
+    public static ValueType jdbcType2DataType(int jdbcType) {
+        SqlTypeName sqlTypeName = SqlTypeName.getNameForJdbcType(jdbcType);
+        SqlTypeFamily family;
+        if (sqlTypeName == null) {
+            family = SqlTypeFamily.getFamilyForJdbcType(jdbcType);
         } else {
             family = sqlTypeName.getFamily();
         }

--- a/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/jdbc/adapters/JdbcDataProviderAdapter.java
+++ b/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/jdbc/adapters/JdbcDataProviderAdapter.java
@@ -394,9 +394,9 @@ public class JdbcDataProviderAdapter implements Closeable {
     protected List<Column> getColumns(ResultSet rs) throws SQLException {
         ArrayList<Column> columns = new ArrayList<>();
         for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
-            String columnTypeName = rs.getMetaData().getColumnTypeName(i);
+            int columnType = rs.getMetaData().getColumnType(i);
             String columnName = rs.getMetaData().getColumnLabel(i);
-            ValueType valueType = DataTypeUtils.sqlType2DataType(columnTypeName);
+            ValueType valueType = DataTypeUtils.jdbcType2DataType(columnType);
             columns.add(Column.of(valueType, columnName));
         }
         return columns;


### PR DESCRIPTION
新建数据视图时如果数据源是PG类，数据模型的字段类型很多解析不出来，因为使用了columnTypeName（String)作为解析，PG存在int4、int8之类的名称，使用jdbc columnType(int)会更加通用
data type in data model is wrong when create data view, it cause by 
use jdbc column type name(String) to parse, this method cannot parse correct when  type name  like int4、int8, change to use use jdbc column type(int),is more general
![图片](https://user-images.githubusercontent.com/25319167/184585379-bca588fb-4045-486d-a9b8-d7e540a53bf2.png)
