### PR TITLE
fix: 修复资源迁移导入目录的时候没设置目录新的组织id问题

### DIFF
--- a/server/src/main/java/datart/server/service/impl/FolderServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/FolderServiceImpl.java
@@ -221,6 +221,7 @@ public class FolderServiceImpl extends BaseService implements FolderService {
             } catch (Exception e) {
                 folder.setName(DateUtils.withTimeString(folder.getName()));
             }
+            folder.setOrgId(orgId);
             folderMapper.insert(folder);
         }
 //        Folder root = null;


### PR DESCRIPTION
在使用资源迁移的功能的时候，我导出一个包含目录的仪表板 & 数据图表 资源，然后，导入到其他组织的时候，发现找不到这些资源了

看了一下代码，应该是导入的时候，插入新的目录时，没设置新的目录组织id为新的组织id，导致在新的组织id中找不到对应目录；我这里就在插入新目录的时候，重新设置了一下组织id



可以用demo 环境中这个导出，再导入其他组织看
http://datart-demo.retech.cc/organizations/906b5ecb8ade4d6d88a708c26ffd76b5/vizs/32f856a507ab4d70a184b2ed83b67a17


麻烦大佬帮忙 review看看了
