### PR TITLE
bugfix: javassist 重复调用toClass导致报错

### DIFF
--- a/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
+++ b/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
@@ -226,7 +226,14 @@ public class ProviderManager extends DataProviderExecuteOptimizer implements Dat
         ServiceLoader<DataProvider> load = ServiceLoader.load(DataProvider.class);
         for (DataProvider dataProvider : load) {
             try {
-                cachedDataProviders.put(dataProvider.getType(), dataProvider);
+                if (!cachedDataProviders.containsKey(dataProvider.getType())) {
+                    synchronized (ProviderManager.class) {
+                        // double check in sync
+                        if (!cachedDataProviders.containsKey(dataProvider.getType())) {
+                            cachedDataProviders.put(dataProvider.getType(), dataProvider);
+                        }
+                    }
+                }
             } catch (IOException e) {
                 log.error("", e);
             }


### PR DESCRIPTION
报错信息以及故障排查在这个Issue #1912 

主要是loadProviders接口每次调用都会重新初始化Provider的缓存，导致后续获取Provider时，有把初始化逻辑重新走了一遍，初始化逻辑中新增的那部分javassist代码重复执行会报错。

加锁的原因是loadProvider页面会并发很多次，测试下来会有概率触发导致报错。

采用双重判断，仅在第一次未加载缓存时可能会进入锁，已初始化时会直接返回。