### PR TITLE
feat: Added two tree controllers for dashboard

### DIFF
--- a/frontend/src/app/migration/__tests__/migrateChartConfig.test.ts
+++ b/frontend/src/app/migration/__tests__/migrateChartConfig.test.ts
@@ -144,7 +144,7 @@ describe('test RC2 Function ', () => {
       ],
     } as any;
     const result = RC2(chartConfig as any);
-    console.log(JSON.stringify(result), 'result');
+
     expect(result.chartConfig.datas[0].rows[0].colName).toEqual(
       'birthday' + DATE_LEVEL_DELIMITER + 'AGG_DATE_YEAR',
     );

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/Controller/TreeController.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/Controller/TreeController.tsx
@@ -15,16 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Form, TreeSelect } from 'antd';
-import { SelectValue } from 'antd/lib/select';
+import { Form, Tree, TreeSelect } from 'antd';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import { RelationFilterValue } from 'app/types/ChartConfig';
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import styled from 'styled-components/macro';
 
-export interface SelectControllerProps {
-  options?: RelationFilterValue[];
-  value?: SelectValue;
+export interface TreeControllerFormProps {
+  treeData?: RelationFilterValue[];
+  value?: string[];
   placeholder?: string;
   onChange: (values) => void;
   label?: React.ReactNode;
@@ -33,7 +32,7 @@ export interface SelectControllerProps {
   parentField?: string[];
 }
 
-export const TreeControllerForm: React.FC<SelectControllerProps> = memo(
+export const TreeControllerForm: React.FC<TreeControllerFormProps> = memo(
   ({ label, name, required, ...rest }) => {
     return (
       <Form.Item
@@ -47,23 +46,43 @@ export const TreeControllerForm: React.FC<SelectControllerProps> = memo(
     );
   },
 );
-export const TreeSelectController: React.FC<SelectControllerProps> = memo(
-  ({ options, onChange, value, parentField }) => {
+export const TreeSelectController: React.FC<TreeControllerFormProps> = memo(
+  ({ treeData, onChange, value }) => {
     const t = useI18NPrefix(`viz.common.enum.controllerPlaceHolders`);
+    const handleonChange = useCallback(
+      checkedObj => {
+        onChange(checkedObj?.checked);
+      },
+      [onChange],
+    );
+
     return (
       <StyledTreeSelect
-        showSearch
         allowClear
         value={value}
         style={{ width: '100%' }}
         placeholder={t('treeSelectController')}
         maxTagTextLength={4}
         maxTagCount={3}
-        optionFilterProp="label"
         onChange={onChange}
         multiple
         bordered={false}
-        treeData={options}
+        treeData={treeData}
+        dropdownStyle={{ height: '300px', overflowY: 'auto' }}
+        dropdownRender={() => {
+          return (
+            <Tree
+              checkedKeys={value}
+              onCheck={handleonChange}
+              checkable
+              checkStrictly
+              titleRender={node => {
+                return node.title || node.key;
+              }}
+              treeData={treeData}
+            />
+          );
+        }}
       />
     );
   },
@@ -73,6 +92,5 @@ const StyledTreeSelect = styled(TreeSelect)`
 
   &.ant-select .ant-select-selector {
     background-color: transparent !important;
-    /* border: none; */
   }
 `;

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/Controller/TreeController.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/Controller/TreeController.tsx
@@ -30,7 +30,7 @@ export interface SelectControllerProps {
   label?: React.ReactNode;
   name?: string;
   required?: boolean;
-  parentField?: string;
+  parentField?: string[];
 }
 
 export const TreeControllerForm: React.FC<SelectControllerProps> = memo(
@@ -63,25 +63,8 @@ export const TreeSelectController: React.FC<SelectControllerProps> = memo(
         onChange={onChange}
         multiple
         bordered={false}
-      >
-        {options?.map(item => (
-          <TreeSelect.TreeNode
-            value={item.key}
-            title={item.key}
-            selectable={!parentField}
-          >
-            {item.children?.map(children => {
-              return (
-                <TreeSelect.TreeNode
-                  key={children.key + children.label}
-                  title={children.label ?? children.key ?? 'none'}
-                  value={children.key}
-                />
-              );
-            })}
-          </TreeSelect.TreeNode>
-        ))}
-      </StyledTreeSelect>
+        treeData={options}
+      />
     );
   },
 );

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/ControllerWidgetCore.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/ControllerWidgetCore.tsx
@@ -363,7 +363,7 @@ export const ControllerWidgetCore: React.FC<{}> = memo(() => {
           <TreeControllerForm
             parentField={parentField}
             onChange={onControllerChange}
-            options={optionRows}
+            treeData={optionRows}
             name={'value'}
             label={leftControlLabel}
           />

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/ControllerWidgetCore.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/ControllerWidget/ControllerWidgetCore.tsx
@@ -31,7 +31,7 @@ import produce from 'immer';
 import React, { memo, useCallback, useContext, useMemo } from 'react';
 import styled from 'styled-components/macro';
 import { isEmpty } from 'utils/object';
-import { convertToTreeData } from '../../../utils/widget';
+import { convertToTree } from '../../../utils/widget';
 import { WidgetActionContext } from '../../ActionProvider/WidgetActionProvider';
 import { WidgetTitle } from '../../WidgetComponents/WidgetTitle';
 import { getWidgetTitle } from '../../WidgetManager/utils/utils';
@@ -75,6 +75,7 @@ export const ControllerWidgetCore: React.FC<{}> = memo(() => {
     valueOptions,
     valueOptionType,
     parentField,
+    treeType,
     // sqlOperator,
   } = useMemo(() => config as ControllerConfig, [config]);
   const title = getWidgetTitle(widget.config.customConfig.props);
@@ -105,8 +106,8 @@ export const ControllerWidgetCore: React.FC<{}> = memo(() => {
     const dataRows = dataset?.rows || [];
 
     if (valueOptionType === 'common') {
-      if (parentField) {
-        return convertToTreeData(dataRows);
+      if (parentField?.length) {
+        return convertToTree(dataRows, treeType);
       }
       return dataRows.map(ele => {
         const item: RelationFilterValue = {
@@ -121,7 +122,7 @@ export const ControllerWidgetCore: React.FC<{}> = memo(() => {
     } else {
       return [];
     }
-  }, [dataset?.rows, valueOptionType, valueOptions, parentField]);
+  }, [dataset?.rows, valueOptionType, valueOptions, parentField, treeType]);
 
   const onControllerChange = useCallback(() => {
     form.submit();

--- a/frontend/src/app/pages/DashBoardPage/pages/Board/slice/thunk.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/Board/slice/thunk.ts
@@ -501,7 +501,7 @@ export const getControllerOptions = createAsyncThunk<
     const view = viewMap[viewId];
     if (!view) return null;
     if (parentField) {
-      columns.push(parentField);
+      columns.push(...parentField);
     }
 
     const requestParams = getControlOptionQueryParams({

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeSetter/TreeSetter.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeSetter/TreeSetter.tsx
@@ -21,9 +21,10 @@ import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import styled from 'styled-components/macro';
 
 export interface TreeSetterProps {
-  onChange?: (value: string) => void;
+  onChange?: (value: string | string[]) => void;
   value?: string;
   style: object;
+  mode?: 'multiple' | 'tags';
   viewFieldList;
 }
 
@@ -31,6 +32,7 @@ function TreeSetter({
   viewFieldList,
   value: val,
   style,
+  mode,
   onChange,
 }: TreeSetterProps) {
   const tc = useI18NPrefix(`viz.control`);
@@ -38,6 +40,7 @@ function TreeSetter({
     <TreeSetterWrapper>
       <Select
         style={style}
+        mode={mode}
         optionFilterProp={'label'}
         onChange={onChange}
         placeholder={tc('parentFieldId')}

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/TreeTypeSetter.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/TreeTypeSetter.tsx
@@ -1,0 +1,66 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Form, FormInstance, Radio, Tooltip } from 'antd';
+import useI18NPrefix from 'app/hooks/useI18NPrefix';
+import { ControllerWidgetContent } from 'app/pages/DashBoardPage/pages/Board/slice/types';
+import { useCallback } from 'react';
+import { ControllerConfig } from '../../../types';
+
+export interface TreeTypeSetterProps {
+  form: FormInstance<ControllerWidgetContent> | undefined;
+}
+
+function TreeTypeSetter({ form }: TreeTypeSetterProps) {
+  const t = useI18NPrefix('viz.control');
+
+  const getControllerConfig = useCallback(() => {
+    return form?.getFieldValue('config') as ControllerConfig;
+  }, [form]);
+
+  const handleChangeFn = useCallback(() => {
+    form?.setFieldsValue({
+      config: {
+        ...getControllerConfig,
+        parentField: undefined,
+        controllerValues: [],
+        valueOptions: [],
+        assistViewFields: [],
+      },
+    });
+  }, [form, getControllerConfig]);
+
+  return (
+    <Form.Item
+      shouldUpdate
+      label={t('treeSelectType')}
+      name={['config', 'treeType']}
+    >
+      <Radio.Group onChange={handleChangeFn}>
+        <Tooltip title={t('treeControlTip')}>
+          <Radio.Button value="treeControl">{t('treeControl')}</Radio.Button>
+        </Tooltip>
+        <Tooltip title={t('treeSelectTip')}>
+          <Radio.Button value="treeSelect">{t('treeSelect')}</Radio.Button>
+        </Tooltip>
+      </Radio.Group>
+    </Form.Item>
+  );
+}
+
+export default TreeTypeSetter;

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/TreeTypeSetter.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/TreeTypeSetter.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Form, FormInstance, Radio, Tooltip } from 'antd';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
 import { ControllerWidgetContent } from 'app/pages/DashBoardPage/pages/Board/slice/types';
@@ -52,12 +52,19 @@ function TreeTypeSetter({ form }: TreeTypeSetterProps) {
       name={['config', 'treeType']}
     >
       <Radio.Group onChange={handleChangeFn}>
-        <Tooltip title={t('treeControlTip')}>
-          <Radio.Button value="treeControl">{t('treeControl')}</Radio.Button>
-        </Tooltip>
-        <Tooltip title={t('treeSelectTip')}>
-          <Radio.Button value="treeSelect">{t('treeSelect')}</Radio.Button>
-        </Tooltip>
+        <Radio.Button value="treeControl">
+          {t('treeControl') + ' '}
+          <Tooltip title={t('treeControlTip')}>
+            <QuestionCircleOutlined />
+          </Tooltip>
+        </Radio.Button>
+
+        <Radio.Button value="treeSelect">
+          {t('treeSelect') + ' '}
+          <Tooltip title={t('treeSelectTip')}>
+            <QuestionCircleOutlined />
+          </Tooltip>
+        </Radio.Button>
       </Radio.Group>
     </Form.Item>
   );

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/TreeTypeSetter/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import TreeTypeSetter from './TreeTypeSetter';
+
+export default TreeTypeSetter;

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/ValuesOptionsSetter/ValuesOptionsSetter.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/ValuesSetter/ValuesOptionsSetter/ValuesOptionsSetter.tsx
@@ -16,7 +16,15 @@
  * limitations under the License.
  */
 
-import { Form, FormInstance, Radio, Select, Space, TreeSelect } from 'antd';
+import {
+  Form,
+  FormInstance,
+  Radio,
+  Select,
+  Space,
+  Tree,
+  TreeSelect,
+} from 'antd';
 import { CascaderOptionType } from 'antd/lib/cascader';
 import { ControllerFacadeTypes } from 'app/constants';
 import useI18NPrefix from 'app/hooks/useI18NPrefix';
@@ -50,6 +58,7 @@ import { ControllerConfig } from '../../../types';
 import TreeSetter from '../TreeSetter';
 import { AssistViewFields } from './AssistViewFields';
 import { CustomOptions } from './CustomOptions';
+
 export interface optionProps {
   label: string;
   value: string;
@@ -150,9 +159,20 @@ const ValuesOptionsSetter: FC<{
     };
   }, []);
 
-  const onTargetKeyChange = useCallback(nextTargetKeys => {
-    setTargetKeys(nextTargetKeys);
-  }, []);
+  const onTargetKeyChange = useCallback(
+    nextTargetKeys => {
+      const config: ControllerConfig = getControllerConfig();
+
+      form?.setFieldsValue({
+        config: {
+          ...config,
+          controllerValues: nextTargetKeys,
+        },
+      });
+      setTargetKeys(nextTargetKeys);
+    },
+    [form, getControllerConfig],
+  );
 
   const fetchNewDataset = useCallback(
     async (viewId: string, columns: string[], dataView?: ChartDataView) => {
@@ -399,15 +419,40 @@ const ValuesOptionsSetter: FC<{
                     <Form.Item name={['config', 'controllerValues']}>
                       {getParentField()?.length ? (
                         <TreeSelect
-                          showSearch
                           placeholder={tc('selectDefaultValue')}
-                          value={targetKeys}
                           multiple
                           allowClear
-                          onChange={onTargetKeyChange}
-                          style={{ width: '100%' }}
                           treeData={optionValues}
-                        ></TreeSelect>
+                          style={{ width: '100%' }}
+                          dropdownStyle={{ height: '300px', overflowY: 'auto' }}
+                          dropdownRender={() => {
+                            return (
+                              <TreeSelectProps
+                                checkedKeys={targetKeys}
+                                onCheck={(checkedObj: any) =>
+                                  onTargetKeyChange(checkedObj?.checked)
+                                }
+                                checkable
+                                checkStrictly
+                                titleRender={node => {
+                                  return (
+                                    <div
+                                      style={{
+                                        width: '100%',
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                      }}
+                                    >
+                                      <span>{node.title || node.key}</span>
+                                      <FieldKey>{node.key}</FieldKey>
+                                    </div>
+                                  );
+                                }}
+                                treeData={optionValues}
+                              />
+                            );
+                          }}
+                        />
                       ) : (
                         <Select
                           showSearch
@@ -465,4 +510,13 @@ const Wrapper = styled.div`
 
 const FieldKey = styled.span`
   color: ${p => p.theme.textColorDisabled};
+`;
+
+const TreeSelectProps = styled(Tree)`
+  .ant-tree-node-content-wrapper {
+    width: 100%;
+  }
+  .ant-tree-treenode {
+    width: 100%;
+  }
 `;

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/ControllerConfig/index.tsx
@@ -31,6 +31,7 @@ import { RadioStyleForm } from './OtherSetter/RadioStyle/RadioStyleForm';
 import { SliderMarks } from './OtherSetter/SliderStyle/SliderMarks';
 import { SliderStep } from './OtherSetter/SliderStyle/SliderStep';
 import { SqlOperator } from './OtherSetter/SqlOperator';
+import TreeTypeSetter from './ValuesSetter/TreeTypeSetter';
 import { ValuesSetter } from './ValuesSetter/ValuesSetter';
 
 export const ControllerValuesName = ['config', 'controllerValues'];
@@ -88,6 +89,10 @@ export const WidgetControlForm: React.FC<RelatedViewFormProps> = memo(
       return controllerType === ControllerFacadeTypes.RadioGroup;
     }, [controllerType]);
 
+    const isTree = useMemo(() => {
+      return controllerType === ControllerFacadeTypes.DropDownTree;
+    }, [controllerType]);
+
     const boardAllWidgetNames = useMemo(() => {
       return (boardVizs || [])
         .filter(bvz => bvz?.id !== wid)
@@ -102,6 +107,7 @@ export const WidgetControlForm: React.FC<RelatedViewFormProps> = memo(
       ];
       return sliderTypes.includes(controllerType);
     }, [controllerType]);
+
     return (
       <Wrapper>
         <Form.Item
@@ -128,6 +134,8 @@ export const WidgetControlForm: React.FC<RelatedViewFormProps> = memo(
         >
           <Input />
         </Form.Item>
+        {isTree && <TreeTypeSetter form={form} />}
+
         <ValuesSetter
           controllerType={controllerType}
           form={form}

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/index.tsx
@@ -301,6 +301,7 @@ const ControllerWidgetPanel: React.FC<WidgetControllerPanelParams> = memo(
       setRelatedWidgets(relatedWidgets);
       setFormRelatedViews(setViewsRelatedView(relatedWidgets));
     };
+
     return (
       <Modal
         title={`${tGMT(type)}${t(controllerType || '')}`}

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/types.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/types.ts
@@ -41,7 +41,8 @@ export interface ControllerConfig {
   canChangeSqlOperator?: boolean; // 是否显示 sqlOperator 切换
   assistViewFields?: string[]; //辅助添加view字段
   controllerDate?: ControllerDate; //存储时间
-  parentField?: string; //父节点字段
+  parentField?: string[]; //父节点字段
+  treeType?: 'treeControl' | 'treeSelect'; //树控制器类型
 
   minValue?: number; // slider min
   maxValue?: number; // slider max

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/utils.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/ControllerWidgetPanel/utils.ts
@@ -289,6 +289,8 @@ export const getRangeValueControllerConfig = () => {
 export const getDropdownTreeControllerConfig = () => {
   const config = getInitControllerConfig();
   config.sqlOperator = FilterSqlOperator.In;
+  config.treeType = 'treeControl';
+  config.parentField = [];
   return config;
 };
 

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/slice/thunk.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/slice/thunk.ts
@@ -681,7 +681,7 @@ export const getEditControllerOptions = createAsyncThunk<
     const view = viewMap[viewId];
     if (!view) return null;
     if (parentField) {
-      columns.push(parentField);
+      columns.push(...parentField);
     }
     const requestParams = getControlOptionQueryParams({
       view,

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -851,9 +851,7 @@ export const convertToTree = (col, type) => {
       parent[parent.length - 1],
     );
   } else {
-    copyCol?.forEach(arr => {
-      [arr[0], arr[arr.length - 1]] = [arr[arr.length - 1], arr[0]];
-    });
+    copyCol?.forEach(arr => arr.reverse());
 
     data = converListToTree(handleRowDataForTree(copyCol));
   }

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -779,41 +779,86 @@ export function cloneWidgets(args: {
     newWidgets,
   };
 }
+/**
+ *
+ * @param collection [[grandpa dad son,....]]
+ * @returns [{id:'',parentId:'',value:''}....]
+ */
+export const handleRowDataForTree = collection => {
+  let obj = {};
+  collection?.forEach(v => {
+    v.forEach((val, ind) => {
+      if (!obj[val] || obj[val]?.isLeaf) {
+        obj[val] = {
+          id: val,
+          parentId: ind ? v[ind - 1] : null,
+          isLeaf: ind === v.length - 1 ? true : false,
+        };
+      }
+    });
+  });
+  return Object.values(obj);
+};
 
-export const convertToTreeData = collection => {
-  const treeNode: { [key: string]: RelationFilterValue } = {};
-
-  collection.forEach(ele => {
-    const parentTitle = ele[ele.length - 1];
-    if (!treeNode[parentTitle]) {
-      treeNode[parentTitle] = {
-        key: parentTitle,
-        label: parentTitle,
-        children: [],
-      };
+export const converListToTree = (
+  list,
+  parentId: null | string = null,
+): any[] => {
+  if (!list) {
+    return list;
+  }
+  const treeNodes: any[] = [];
+  const childrenList: any = [];
+  list.forEach(o => {
+    if (o['parentId'] === parentId) {
+      treeNodes.push({
+        id: o['id'],
+        parentId: o['parentId'],
+        value: o['id'],
+        title: o['label'] || o['id'],
+        label: o['label'] || o['id'],
+      });
+    } else {
+      childrenList.push(o);
     }
-    treeNode[parentTitle]['children'] = [
-      ...(treeNode[parentTitle]['children'] as []),
-      {
-        key: ele?.[0],
-        label: ele.length > 2 ? ele?.[1] : undefined,
-      },
-    ];
   });
 
-  Object.entries(treeNode)?.forEach(([key, value], ind) => {
-    treeNode[key] = {
-      ...value,
-      index: ind,
-      children: value.children?.map((children, index) => {
+  return treeNodes.map(node => {
+    const children = converListToTree(childrenList, node.id);
+    return children?.length ? { ...node, children } : { ...node, isLeaf: true };
+  });
+};
+
+export const convertToTree = (col, type) => {
+  if (!col && !col.length) {
+    return col;
+  }
+
+  let data: RelationFilterValue[] = [];
+  let copyCol = CloneValueDeep(col);
+  let emptyParentObj = ['null', 'undefined', 'false'];
+
+  if (type === 'treeControl') {
+    const parent = copyCol?.find(
+      v => !v[v.length - 1] || emptyParentObj.includes(v[v.length - 1]),
+    ) || [null];
+    data = converListToTree(
+      copyCol?.map(v => {
         return {
-          ...children,
-          index: ind,
-          childIndex: index,
+          id: v[0],
+          parentId: v[v.length - 1],
+          label: v.length > 2 ? v[1] : v[0],
         };
       }),
-    };
-  });
+      parent[parent.length - 1],
+    );
+  } else {
+    copyCol?.forEach(arr => {
+      [arr[0], arr[arr.length - 1]] = [arr[arr.length - 1], arr[0]];
+    });
 
-  return Object.values(treeNode);
+    data = converListToTree(handleRowDataForTree(copyCol));
+  }
+
+  return data;
 };

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -836,11 +836,11 @@ export const convertToTree = (col, type) => {
 
   let data: RelationFilterValue[] = [];
   let copyCol = CloneValueDeep(col);
-  let emptyParentObj = ['null', 'undefined', 'false'];
+  let emptyParentList = ['null', 'undefined', 'false'];
 
   if (type === 'treeControl') {
     const parent = copyCol?.find(
-      v => !v[v.length - 1] || emptyParentObj.includes(v[v.length - 1]),
+      v => !v[v.length - 1] || emptyParentList.includes(v[v.length - 1]),
     ) || [null];
     data = converListToTree(
       copyCol?.map(v => {

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -792,7 +792,6 @@ export const handleRowDataForTree = collection => {
         obj[val] = {
           id: val,
           parentId: ind ? v[ind - 1] : null,
-          isLeaf: ind === v.length - 1 ? true : false,
         };
       }
     });
@@ -814,9 +813,8 @@ export const converListToTree = (
       treeNodes.push({
         id: o['id'],
         parentId: o['parentId'],
-        value: o['id'],
+        key: o['id'],
         title: o['label'] || o['id'],
-        label: o['label'] || o['id'],
       });
     } else {
       childrenList.push(o);

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -780,7 +780,7 @@ export function cloneWidgets(args: {
   };
 }
 /**
- *
+ * @describe list[grandpa dad son...] to List[{id:'',parentId:''}]
  * @param collection [[grandpa dad son,....]]
  * @returns [{id:'',parentId:'',value:''}....]
  */

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1281,7 +1281,12 @@
       "setDefault": "Set Default",
       "delete": "Delete",
       "populate": "Populate From Field Values",
-      "parentFieldId": "Select Parent Field"
+      "parentFieldId": "Select Parent Field",
+      "treeSelectType": "Select Tree Type",
+      "treeControl": "Tree Control",
+      "treeControlTip": "Multi-level structure list (folders, organizational structures, categories, countries, etc. Use tree controls to fully display hierarchical relationships.)",
+      "treeSelect": "Tree Select",
+      "treeSelectTip": "Tree selection control (can be used when the optional data structure is a tree structure, such as company hierarchy, subject system, taxonomy, etc.)"
     },
     "date": {
       "year": "Year",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -1279,7 +1279,12 @@
       "setDefault": "设为默认值",
       "delete": "删除",
       "populate": "从字段填充备选项",
-      "parentFieldId": "父ID字段"
+      "parentFieldId": "父ID字段",
+      "treeSelectType": "树类型选择",
+      "treeControl": "树形控件",
+      "treeControlTip": "多层次的结构列表（文件夹、组织架构、生物分类、国家地区等等。使用 树控件 可以完整展现其中的层级关系。）",
+      "treeSelect": "树选择",
+      "treeSelectTip": "树型选择控件（可选择的数据结构是一个树形结构时，可以使用，例如公司层级、学科系统、分类目录等等。）"
     },
     "date": {
       "year": "年",


### PR DESCRIPTION
dashboard的树控制器支持了两种数据模型

一种是树形控件：类似于这样的数据，parentId和id对应,无限嵌套的数据

![image](https://user-images.githubusercontent.com/32259371/186874564-2fd993d5-734e-4ab1-ac73-4f49f2a512ad.png)

一种是树选择：可以参考以下数据, name_level1是顶级目录，name_level2 是name_level1的子目录，name_level3 是name_level2的子目录

![image](https://user-images.githubusercontent.com/32259371/186876714-264afafa-6725-4fc5-8d4e-27c40981a457.png)

展示截图：
![image](https://user-images.githubusercontent.com/32259371/186873864-35a4dba2-f318-4c9c-bc38-ccf82227f437.png)

![image](https://user-images.githubusercontent.com/32259371/186873894-79e06f48-24f2-419c-8e1e-b143043f2171.png)

<img width="634" alt="image" src="https://user-images.githubusercontent.com/32259371/187071352-7affcfca-6739-4015-b2fb-33fd1e66f604.png">
<img width="660" alt="image" src="https://user-images.githubusercontent.com/32259371/187071364-4d94f2f2-146f-4328-bea0-5f217ee0a73a.png">


