### PR TITLE
Feat-同比环比

### DIFF
--- a/core/src/main/java/datart/core/common/DateUtils.java
+++ b/core/src/main/java/datart/core/common/DateUtils.java
@@ -63,4 +63,9 @@ public class DateUtils {
         return name + DateFormatUtils.format(new Date(), DateFormatUtils.format(new Date(), "yyyy-MM-dd HH:mm:ss.SSS"));
     }
 
+
+    public static String quarterToMonth(String quarterDate) {
+        int quarter = quarterDate.charAt(quarterDate.length() - 1) - '0';
+        return quarterDate.substring(0, quarterDate.length() - 2) + "-" + String.format("%02d", 1 + (quarter - 1) * 3);
+    }
 }

--- a/core/src/main/java/datart/core/data/provider/Column.java
+++ b/core/src/main/java/datart/core/data/provider/Column.java
@@ -19,6 +19,7 @@
 package datart.core.data.provider;
 
 import datart.core.base.consts.ValueType;
+import datart.core.data.provider.sql.AggregateOperator;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -34,6 +35,8 @@ public class Column implements Serializable {
     private String fmt;
 
     private List<ForeignKey> foreignKeys;
+
+    private AggregateOperator.CalcOperator calc;
 
     public Column(String[] name, ValueType type) {
         this.name = name;

--- a/core/src/main/java/datart/core/data/provider/sql/AggregateOperator.java
+++ b/core/src/main/java/datart/core/data/provider/sql/AggregateOperator.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(callSuper = true)
 public class AggregateOperator extends ColumnOperator implements Alias {
 
+    private CalcOperator calcOperator;
     private SqlOperator sqlOperator;
 
     private String alias;
@@ -47,10 +48,18 @@ public class AggregateOperator extends ColumnOperator implements Alias {
         COUNT_DISTINCT,
     }
 
+    public enum CalcOperator implements Serializable {
+
+        RATIO_YEAR,
+
+        RATIO_LAST,
+    }
+
     @Override
     public String toString() {
         return "AggregateOperator{" +
                 "sqlOperator=" + sqlOperator +
+                ", calcOperator=" + calcOperator +
                 ", column='" + getColumnKey() + '\'' +
                 '}';
     }

--- a/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
+++ b/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
@@ -21,26 +21,37 @@ package datart.data.provider;
 import datart.core.base.processor.ExtendProcessor;
 import datart.core.base.exception.Exceptions;
 import datart.core.base.processor.ProcessorResponse;
+import datart.core.common.DateUtils;
 import datart.core.data.provider.*;
 import datart.core.data.provider.processor.DataProviderPostProcessor;
 import datart.core.data.provider.processor.DataProviderPreProcessor;
+import datart.core.data.provider.sql.AggregateOperator;
+import datart.core.data.provider.sql.FunctionColumn;
+import datart.core.data.provider.sql.GroupByOperator;
 import datart.data.provider.optimize.DataProviderExecuteOptimizer;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.SQLException;
+import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 public class ProviderManager extends DataProviderExecuteOptimizer implements DataProviderManager {
 
     @Autowired(required = false)
-    private List<ExtendProcessor> extendProcessors = new ArrayList<ExtendProcessor>();
+    private List<ExtendProcessor> extendProcessors = new ArrayList<>();
 
     private static final Map<String, DataProvider> cachedDataProviders = new ConcurrentSkipListMap<>();
 
@@ -237,7 +248,135 @@ public class ProviderManager extends DataProviderExecuteOptimizer implements Dat
     public Dataframe run(DataProviderSource source, QueryScript queryScript, ExecuteParam param) throws Exception {
         Dataframe dataframe = getDataProviderService(source.getType()).execute(source, queryScript, param);
         excludeColumns(dataframe, param.getIncludeColumns());
+        calc(dataframe, param);
         return dataframe;
     }
 
+    /**
+     * 高级计算(运算后替换原值)
+     *
+     * @param dataframe
+     * @param executeParam
+     */
+    private void calc(Dataframe dataframe, ExecuteParam executeParam) {
+        //判断是否需要进行快速计算
+        List<AggregateOperator> operators = executeParam.getAggregators();
+        int calcIndex = ListUtils.indexOf(operators, aggregateOperator -> aggregateOperator.getCalcOperator() != null);
+        if (calcIndex == -1) {
+            return;
+        }
+
+        List<List<Object>> rows = dataframe.getRows();
+        List<Column> columns = dataframe.getColumns();
+        List<GroupByOperator> groups = executeParam.getGroups();
+        int groupSize = groups.size();
+
+        for (int i = calcIndex, j = operators.size(); i < j; i++) {
+            AggregateOperator aggregateOperator = operators.get(i);
+            if (aggregateOperator.getCalcOperator() == null) {
+                continue;
+            }
+            int dataIndex = groupSize + i;
+
+            //替换列名
+            columns.get(dataIndex).setCalc(aggregateOperator.getCalcOperator());
+
+            Map<String, BigDecimal> currentMap = new LinkedHashMap<>();
+            if (aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_YEAR || aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_LAST) {
+                //判断是否存在日期聚合维度,并搜索最小维度
+                EnumSet<StdSqlOperator> set = EnumSet.of(StdSqlOperator.AGG_DATE_YEAR, StdSqlOperator.AGG_DATE_QUARTER, StdSqlOperator.AGG_DATE_MONTH, StdSqlOperator.AGG_DATE_WEEK, StdSqlOperator.AGG_DATE_DAY);
+                List<FunctionColumn> functionColumns = executeParam.getFunctionColumns();
+                List<Integer> ordinals = functionColumns.stream().map(functionColumn -> {
+                    Optional<StdSqlOperator> optional = set.stream().filter(std -> functionColumn.getSnippet().startsWith(std.getSymbol())).findFirst();
+                    return optional.map(Enum::ordinal).orElse(0);
+                }).collect(Collectors.toList());
+                //取最小粒度的时间维度
+                FunctionColumn fc = functionColumns.get(ordinals.indexOf(ordinals.stream().max((Comparator.naturalOrder())).get()));
+                int timeIndex = ListUtils.indexOf(executeParam.getGroups(), groupByOperator -> groupByOperator.getAlias().equals(fc.getAlias()));
+                StdSqlOperator stdSqlOperator = set.stream().filter(std -> fc.getSnippet().startsWith(std.getSymbol())).findFirst().get();
+
+
+                //将所有值放到 map 中以便后续快速定位
+                for (List<Object> row : rows) {
+                    BigDecimal origin = new BigDecimal(row.get(dataIndex).toString());
+
+                    String date = row.get(timeIndex).toString();
+                    if (stdSqlOperator == StdSqlOperator.AGG_DATE_QUARTER) {
+                        // 以月份替换季度
+                        currentMap.put(String.format("%s-%s", dimensions(row, groupSize, timeIndex), DateUtils.quarterToMonth(date)), origin);
+                    } else {
+                        currentMap.put(String.format("%s-%s", dimensions(row, groupSize, timeIndex), date), origin);
+                    }
+                }
+
+                for (List<Object> row : rows) {
+                    BigDecimal origin = new BigDecimal(row.get(dataIndex).toString());
+                    String rowDate = row.get(timeIndex).toString();
+                    String calcDate;
+                    String pattern;
+                    int field = Calendar.YEAR;
+                    int amount = -1;
+
+                    if (stdSqlOperator == StdSqlOperator.AGG_DATE_YEAR) {
+                        pattern = "yyyy";
+                    } else if (stdSqlOperator == StdSqlOperator.AGG_DATE_QUARTER) {
+                        pattern = "yyyy-MM";
+                        rowDate = DateUtils.quarterToMonth(rowDate);
+                        if (aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_LAST) {
+                            field = Calendar.MONTH;
+                            amount = -3;
+                        }
+                    } else if (stdSqlOperator == StdSqlOperator.AGG_DATE_MONTH) {
+                        pattern = "yyyy-MM";
+                        if (aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_LAST) {
+                            field = Calendar.MONTH;
+                        }
+                    } else if (stdSqlOperator == StdSqlOperator.AGG_DATE_WEEK) {
+                        pattern = "yyyy-ww";
+                        if (aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_LAST) {
+                            field = Calendar.WEEK_OF_YEAR;
+                        }
+                    } else if (stdSqlOperator == StdSqlOperator.AGG_DATE_DAY) {
+                        pattern = "yyyy-MM-dd";
+                        if (aggregateOperator.getCalcOperator() == AggregateOperator.CalcOperator.RATIO_LAST) {
+                            field = Calendar.DAY_OF_MONTH;
+                        }
+                    } else {
+                        continue;
+                    }
+                    Calendar calendar = Calendar.getInstance();
+                    try {
+                        FastDateFormat dateFormat = FastDateFormat.getInstance(pattern);
+                        Date date = dateFormat.parse(rowDate);
+                        calendar.setTime(date);
+                        calendar.add(field, amount);
+                        calcDate = dateFormat.format(calendar.getTime());
+                    } catch (ParseException e) {
+                        calcDate = rowDate;
+                    }
+
+                    BigDecimal lastValue = currentMap.get(String.format("%s-%s", dimensions(row, groupSize, timeIndex), calcDate));
+                    if (lastValue == null) {
+                        row.set(dataIndex, "");
+                    } else {
+                        row.set(dataIndex, origin
+                                .divide(lastValue, 8, RoundingMode.HALF_UP)
+                                .subtract(new BigDecimal(1))
+                                .setScale(8, RoundingMode.HALF_UP)
+                                .doubleValue());
+                    }
+                }
+            }
+        }
+    }
+
+    private String dimensions(List<Object> row, int size, int timeIndex) {
+        List<Object> dimension = new ArrayList<>();
+        for (int start = 0; start < size; start++) {
+            if(start != timeIndex) {
+                dimension.add(row.get(start));
+            }
+        }
+        return StringUtils.join(dimension, "-");
+    }
 }

--- a/frontend/src/app/components/ChartGraph/BasicTableChart/BasicTableChart.tsx
+++ b/frontend/src/app/components/ChartGraph/BasicTableChart/BasicTableChart.tsx
@@ -513,9 +513,10 @@ class BasicTableChart extends ReactChart {
           headerFont?.fontSize,
           headerFont?.fontFamily,
         );
-        const currentSummaryField = aggregateConfigs.find(
-          ac => ac.uid === c.uid,
-        );
+        const currentSummaryField = aggregateConfigs
+          // 快速计算不参与总计
+          .filter(config => !config.calc)
+          .find(ac => ac.uid === c.uid);
         const total = chartDataSet?.map((dc: any) =>
           dc.getCell(currentSummaryField),
         );

--- a/frontend/src/app/components/ChartGraph/PivotSheetChart/config.ts
+++ b/frontend/src/app/components/ChartGraph/PivotSheetChart/config.ts
@@ -43,7 +43,7 @@ const config: ChartConfig = {
       key: 'metrics',
       type: 'aggregate',
       actions: {
-        NUMERIC: ['aggregate', 'alias', 'format', 'sortable'],
+        NUMERIC: ['aggregate', 'advanceCalc', 'alias', 'format', 'sortable'],
         STRING: ['aggregate', 'alias', 'format', 'sortable'],
       },
       options: {

--- a/frontend/src/app/constants.ts
+++ b/frontend/src/app/constants.ts
@@ -118,6 +118,12 @@ export enum AggregateFieldActionType {
   Min = 'MIN',
 }
 
+export enum AdvanceCalcFieldActionType {
+  None = 'NONE',
+  Ratio_Year = 'RATIO_YEAR',
+  Ratio_Last = 'RATIO_LAST',
+}
+
 export enum ChartDataSectionType {
   Group = 'group',
   Aggregate = 'aggregate',
@@ -159,6 +165,7 @@ export const ChartDataSectionFieldActionType = {
   Format: 'format',
   Aggregate: 'aggregate',
   AggregateLimit: 'aggregateLimit',
+  AdvanceCalc: 'advanceCalc',
   Filter: 'filter',
   CategoryFilter: 'categoryFilter',
   Colorize: 'colorize',
@@ -187,6 +194,14 @@ export const AggregateFieldSubAggregateType = {
   [ChartDataSectionFieldActionType.AggregateLimit]: [
     AggregateFieldActionType.Count,
     AggregateFieldActionType.Count_Distinct,
+  ],
+};
+
+export const AdvanceCalcFieldSubAggregateType = {
+  [ChartDataSectionFieldActionType.AdvanceCalc]: [
+    AdvanceCalcFieldActionType.None,
+    AdvanceCalcFieldActionType.Ratio_Year,
+    AdvanceCalcFieldActionType.Ratio_Last,
   ],
 };
 

--- a/frontend/src/app/hooks/useFieldActionModal.tsx
+++ b/frontend/src/app/hooks/useFieldActionModal.tsx
@@ -66,6 +66,8 @@ function useFieldActionModal({ i18nPrefix }: I18NComponentProps) {
         return <FieldActions.AggregationAction {...props} />;
       case ChartDataSectionFieldActionType.AggregateLimit:
         return <FieldActions.AggregationLimitAction {...props} />;
+      case ChartDataSectionFieldActionType.AdvanceCalc:
+        return <FieldActions.AdvanceCalcAction {...props} />;
       case ChartDataSectionFieldActionType.Filter:
         return <FieldActions.FilterAction {...props} />;
       case ChartDataSectionFieldActionType.Colorize:

--- a/frontend/src/app/models/ChartDataRequestBuilder.ts
+++ b/frontend/src/app/models/ChartDataRequestBuilder.ts
@@ -162,18 +162,25 @@ export class ChartDataRequestBuilder {
         alias: this.buildAliasName(aggCol),
         column: this.buildColumnName(aggCol),
         sqlOperator: aggCol.aggregate!,
+        calcOperator: aggCol.calc!,
       })),
       (a, b) =>
-        isEqualObject(a.column, b.column) && a.sqlOperator === b.sqlOperator,
+        isEqualObject(a.column, b.column) &&
+        a.sqlOperator === b.sqlOperator &&
+        a.calcOperator === b.calcOperator,
     );
   }
 
-  private buildAliasName(c) {
+  private buildAliasName(c: ChartDataSectionField) {
     if (c.aggregate === AggregateFieldActionType.None) {
       return c.colName;
     }
     if (c.aggregate) {
-      return `${c.aggregate}(${c.colName})`;
+      if (!c.calc) {
+        return `${c.aggregate}(${c.colName})`;
+      } else {
+        return `${c.aggregate}(${c.colName})-${c.calc}`;
+      }
     }
     return c.colName;
   }

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDataConfigSection/MixedTypeSection.tsx
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDataConfigSection/MixedTypeSection.tsx
@@ -33,6 +33,7 @@ const MixedTypeSection: FC<ChartDataConfigSectionProps> = memo(
         actions: {
           [DataViewFieldType.NUMERIC]: [
             ChartDataSectionFieldActionType.Aggregate,
+            ChartDataSectionFieldActionType.AdvanceCalc,
             ChartDataSectionFieldActionType.Alias,
             ChartDataSectionFieldActionType.Format,
             ChartDataSectionFieldActionType.Sortable,

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/ChartDataConfigSectionActionMenu.tsx
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartDraggable/ChartDataConfigSectionActionMenu.tsx
@@ -27,6 +27,7 @@ import { ChartDataSectionField } from 'app/types/ChartConfig';
 import { ChartDataConfigSectionProps } from 'app/types/ChartDataConfigSection';
 import { ChartDataViewMeta } from 'app/types/ChartDataViewMeta';
 import { FC } from 'react';
+import AdvanceCalcAction from '../ChartFieldAction/AdvanceCalcAction';
 import AggregationAction from '../ChartFieldAction/AggregationAction';
 import AggregationLimitAction from '../ChartFieldAction/AggregationLimitAction';
 import DateLevelAction from '../ChartFieldAction/DateLevelAction/DateLevelAction';
@@ -57,6 +58,7 @@ const ChartDataConfigSectionActionMenu: FC<
     ChartDataSectionFieldActionType.Sortable,
     ChartDataSectionFieldActionType.Aggregate,
     ChartDataSectionFieldActionType.AggregateLimit,
+    ChartDataSectionFieldActionType.AdvanceCalc,
     ChartDataSectionFieldActionType.DateLevel,
   ];
 
@@ -105,6 +107,7 @@ const ChartDataConfigSectionActionMenu: FC<
           ![
             ChartDataSectionFieldActionType.Aggregate,
             ChartDataSectionFieldActionType.AggregateLimit,
+            ChartDataSectionFieldActionType.AdvanceCalc,
           ].includes(action),
       );
     }
@@ -156,6 +159,17 @@ const ChartDataConfigSectionActionMenu: FC<
     if (actionName === ChartDataSectionFieldActionType.AggregateLimit) {
       return (
         <AggregationLimitAction
+          config={fieldConfig}
+          onConfigChange={(config, needRefresh) => {
+            handleFieldConfigChanged(uid, config, needRefresh);
+          }}
+          mode="menu"
+        />
+      );
+    }
+    if (actionName === ChartDataSectionFieldActionType.AdvanceCalc) {
+      return (
+        <AdvanceCalcAction
           config={fieldConfig}
           onConfigChange={(config, needRefresh) => {
             handleFieldConfigChanged(uid, config, needRefresh);

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartFieldAction/AdvanceCalcAction.tsx
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartFieldAction/AdvanceCalcAction.tsx
@@ -1,0 +1,122 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CheckOutlined } from '@ant-design/icons';
+import { Menu, Radio, Space } from 'antd';
+import {
+  AdvanceCalcFieldActionType,
+  AdvanceCalcFieldSubAggregateType,
+  ChartDataSectionFieldActionType,
+  ChartDataSectionType,
+  DataViewFieldType,
+} from 'app/constants';
+import useI18NPrefix from 'app/hooks/useI18NPrefix';
+import { ChartDataSectionField } from 'app/types/ChartConfig';
+import { updateBy } from 'app/utils/mutation';
+import { FC, useContext, useState } from 'react';
+import ChartPaletteContext from '../../../../contexts/ChartPaletteContext';
+
+const AdvanceCalcAction: FC<{
+  config: ChartDataSectionField;
+  onConfigChange: (
+    config: ChartDataSectionField,
+    needRefresh?: boolean,
+  ) => void;
+  mode?: 'menu';
+}> = ({ config, onConfigChange, mode, ...rest }) => {
+  const t = useI18NPrefix(`viz.common.enum.advanceCalc`);
+
+  const { datas } = useContext(ChartPaletteContext);
+  const actionNeedNewRequest = true;
+  const [calc, setCalc] = useState(config?.calc);
+
+  const onChange = selectedValue => {
+    selectedValue = selectedValue === 'NONE' ? undefined : selectedValue;
+    const newConfig = updateBy(config, draft => {
+      draft.calc = selectedValue;
+    });
+    setCalc(selectedValue);
+    onConfigChange?.(newConfig, actionNeedNewRequest);
+  };
+
+  let items =
+    AdvanceCalcFieldSubAggregateType[
+      ChartDataSectionFieldActionType.AdvanceCalc
+    ] || [];
+
+  // 同环比需要日期维度才能计算
+  if (
+    datas &&
+    datas
+      .filter(
+        c =>
+          c.type === ChartDataSectionType.Group ||
+          c.type === ChartDataSectionType.Mixed,
+      )
+      .filter(
+        c => c.rows?.findIndex(s => s.type === DataViewFieldType.DATE) !== -1,
+      ).length === 0
+  ) {
+    items = items.filter(
+      t =>
+        ![
+          AdvanceCalcFieldActionType.Ratio_Year,
+          AdvanceCalcFieldActionType.Ratio_Last,
+        ].includes(t),
+    );
+  }
+
+  const renderOptions = mode => {
+    if (mode === 'menu') {
+      return (
+        <>
+          {items.map(agg => {
+            return (
+              <Menu.Item
+                key={agg}
+                eventKey={agg}
+                icon={calc === agg ? <CheckOutlined /> : ''}
+                onClick={() => onChange(agg)}
+              >
+                {t(agg)}
+              </Menu.Item>
+            );
+          })}
+        </>
+      );
+    }
+
+    return (
+      <Radio.Group onChange={e => onChange(e.target?.value)} value={calc}>
+        <Space direction="vertical">
+          {items.map(agg => {
+            return (
+              <Radio key={agg} value={agg}>
+                {t(agg)}
+              </Radio>
+            );
+          })}
+        </Space>
+      </Radio.Group>
+    );
+  };
+
+  return renderOptions(mode);
+};
+
+export default AdvanceCalcAction;

--- a/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartFieldAction/index.ts
+++ b/frontend/src/app/pages/ChartWorkbenchPage/components/ChartOperationPanel/components/ChartFieldAction/index.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import AdvanceCalcAction from './AdvanceCalcAction';
 import AggregationAction from './AggregationAction';
 import AggregationColorizeAction from './AggregationColorizeAction';
 import AggregationLimitAction from './AggregationLimitAction';
@@ -35,6 +36,7 @@ const actions = {
   NumberFormatAction,
   SortAction,
   AggregationLimitAction,
+  AdvanceCalcAction,
   FilterAction,
   AggregationColorizeAction,
   SizeOptionsAction,

--- a/frontend/src/app/types/ChartConfig.ts
+++ b/frontend/src/app/types/ChartConfig.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  AdvanceCalcFieldActionType,
   AggregateFieldActionType,
   ChartDataSectionFieldActionType,
   ChartDataSectionType,
@@ -113,6 +114,7 @@ export type ChartDataSectionField = {
   alias?: AliasFieldAction;
   format?: FormatFieldAction;
   aggregate?: AggregateFieldActionType;
+  calc?: AdvanceCalcFieldActionType;
   filter?: FilterFieldAction;
   color?: ColorFieldAction;
   size?: number;

--- a/frontend/src/app/types/ChartDataSet.ts
+++ b/frontend/src/app/types/ChartDataSet.ts
@@ -65,6 +65,8 @@ export type ChartDatasetPageInfo = Partial<PageInfo>;
 export type ChartDatasetMeta = {
   name?: string;
   type?: string;
+  fmt?: string;
+  calc?: string;
   primaryKey?: boolean;
 };
 

--- a/frontend/src/app/utils/chartHelper.ts
+++ b/frontend/src/app/utils/chartHelper.ts
@@ -1083,6 +1083,7 @@ export function transformToObjectArray(
 export function getValueByColumnKey(field?: {
   aggregate?;
   colName: string;
+  calc?;
 }): string {
   if (!field) {
     return '';
@@ -1090,7 +1091,10 @@ export function getValueByColumnKey(field?: {
   if (!field.aggregate) {
     return field.colName;
   }
-  return `${field.aggregate}(${field.colName})`;
+  if (!field.calc) {
+    return `${field.aggregate}(${field.colName})`;
+  }
+  return `${field.aggregate}(${field.colName})-${field.calc}`;
 }
 
 /**

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -368,6 +368,11 @@
           "MAX": "Max",
           "MIN": "Min"
         },
+        "advanceCalc": {
+          "NONE": "None",
+          "RATIO_YEAR": "Ratio_Year",
+          "RATIO_LAST": "Ratio_Last"
+        },
         "controllerFacadeTypes": {
           "dropdownList": "Dropdown List",
           "radioGroup": "Radio Group",
@@ -786,6 +791,7 @@
             "format": "Format",
             "aggregate": "Aggregate",
             "aggregateLimit": "Aggregate",
+            "advanceCalc": "Calculator",
             "filter": "Filter",
             "categoryFilter": "Category Filter",
             "colorize": "Colorize",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -368,6 +368,11 @@
           "MAX": "最大值",
           "MIN": "最小值"
         },
+        "advanceCalc": {
+          "NONE": "无",
+          "RATIO_YEAR": "同比",
+          "RATIO_LAST": "环比"
+        },
         "controllerFacadeTypes": {
           "dropdownList": "下拉列表",
           "radioGroup": "单选按钮",
@@ -784,6 +789,7 @@
             "format": "格式",
             "aggregate": "聚合",
             "aggregateLimit": "聚合",
+            "advanceCalc": "高级计算",
             "filter": "过滤",
             "categoryFilter": "类别过滤",
             "colorize": "着色",


### PR DESCRIPTION
聚合指标增加同环比计算

使用方式:
当图表维度包含时间维度时点击某个聚合指标会显示高级计算, 子菜单有环比、同比、无（取消）
点击环比后会以当前时间维度的最小粒度计算环比


![WechatIMG2103](https://user-images.githubusercontent.com/3031809/188053284-144c4f42-ac1e-4aca-9d00-9861f440205a.jpeg)
![WechatIMG2104](https://user-images.githubusercontent.com/3031809/188053295-30fe8a2c-e05c-47cd-ba64-6e3d0c44cc24.png)

实现方式:
目前的实现方式是基于查询的结果进行计算的, 不涉及多次查询