### PR TITLE
兼容旧版datart 解析列名时，获取不到view实际列的问题

### DIFF
--- a/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
@@ -452,7 +452,7 @@ public class DataProviderServiceImpl extends BaseService implements DataProvider
                             names = item.getJSONArray("name").toArray(new String[0]);
                         }
                     } else {
-                        names = new String[]{item.getString("name")};
+                        names = new String[]{Optional.ofNullable(item.getString("name")).orElse(key)};
                     }
                     Column column = Column.of(ValueType.valueOf(item.getString("type")), names);
                     schema.put(column.columnKey(), column);


### PR DESCRIPTION
最近我在二开datart的时候，发现有时候获取不到view的列信息，后面发现是原解析view列信息的没完全兼容旧版情况，name 属性可能为null的情况

例如下面的例子：

http://datart-demo.retech.cc/organizations/1306a51ec4a44620bdb0fffca8656a1f/views/dc3b88e372cd405d88268715e93bfb5a

![解析name不存在的情况](https://user-images.githubusercontent.com/22886101/193291879-fb5bf564-c406-4677-94e6-b0190e887457.png)


这个view的names 中就是不存在name属性，如果解析会返回null的

解析view的列信息问题，在旧版datart 的时候 view的列信息中 columns 中不存在name 属性字段的，

原代码中 直接 通过 
```java
names = new String[]{item.getString("name")};
 
//  ..........

Column column = Column.of(ValueType.valueOf(item.getString("type")), names);
```
如果之前版本中name 不存在，则得到的 column 对象一直为null，返回也是只有一个null对象，而得不到的实际view的列信息，我这个pr 补充一下空的判断，兼容一下旧版datart情况
