### PR TITLE
refactor: parse schema column order

### DIFF
--- a/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
@@ -22,6 +22,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.parser.Feature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
@@ -428,12 +429,12 @@ public class DataProviderServiceImpl extends BaseService implements DataProvider
      * @param model view.model
      */
     private Map<String, Column> parseSchema(String model) {
-        HashMap<String, Column> schema = new HashMap<>();
+        Map<String, Column> schema = new LinkedHashMap<>();
         if (StringUtils.isBlank(model)) {
             return schema;
         }
 
-        JSONObject jsonObject = JSON.parseObject(model);
+        JSONObject jsonObject = JSON.parseObject(model, Feature.OrderedField);
         try {
             if (jsonObject.containsKey("columns")) {
                 jsonObject = jsonObject.getJSONObject("columns");


### PR DESCRIPTION
我看代码中解析的view的列信息的时候，使用了HashMap ，然后 fastjson 解析的时候也是默认使用了无序的方式，这样解析出的列信息是无序的，但是在view的model属性中存储的列信息是有顺序的，前端解析的时候也是有顺序的，所以我这里优化了一下代码，把后端解析的列信息时也返回有序的，目前不知道有什么地方会后端需要用到有序的地方，但是我觉得保持跟前端解析顺序一样还是比较好



麻烦大佬帮忙code view 一下了