### PR TITLE
优化获取widget的关联信息，修改为批量从数据获取到关联信息

### DIFF
--- a/core/src/main/java/datart/core/mappers/ext/RelWidgetElementMapperExt.java
+++ b/core/src/main/java/datart/core/mappers/ext/RelWidgetElementMapperExt.java
@@ -15,6 +15,16 @@ public interface RelWidgetElementMapperExt extends RelWidgetElementMapper {
     })
     List<RelWidgetElement> listWidgetElements(String widgetId);
 
+    @Select({
+            "<script>",
+            "SELECT * FROM rel_widget_element WHERE widget_id IN " +
+                    "<foreach collection='widgetIds' item='item' index='index' open='(' close=')' separator=','> " +
+                    " #{item} " +
+                    "</foreach>",
+            "</script>"
+    })
+    List<RelWidgetElement> listWidgetElementsByIds(@Param("widgetIds") List<String> widgetId);
+
     @Insert({
             "<script>",
             "INSERT INTO rel_widget_element (id, widget_id, rel_type, rel_id) VALUES " +

--- a/core/src/main/java/datart/core/mappers/ext/RelWidgetWidgetMapperExt.java
+++ b/core/src/main/java/datart/core/mappers/ext/RelWidgetWidgetMapperExt.java
@@ -60,4 +60,14 @@ public interface RelWidgetWidgetMapperExt extends RelWidgetWidgetMapper {
     })
     List<RelWidgetWidget> listTargetWidgets(String sourceId);
 
+    @Select({
+            "<script>",
+            "SELECT rww.* " +
+                    "FROM rel_widget_widget rww " +
+                    "WHERE rww.source_id IN " +
+                    "<foreach collection='sourceIds' item='item' index='index' open='(' close=')' separator=','>  #{item} </foreach> ;",
+            "</script>",
+    })
+    List<RelWidgetWidget> listTargetWidgetsByIds(List<String> sourceIds);
+
 }

--- a/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
@@ -438,6 +438,8 @@ public class DashboardServiceImpl extends BaseService implements DashboardServic
     }
 
     private List<WidgetDetail> getWidgets(String dashboardId, Set<String> datachartIds, Set<String> viewIds) {
+        List<String> widgetIds = new ArrayList<>();
+
         // get all widgets details
         List<Widget> widgets = widgetMapper.listByDashboard(dashboardId);
         List<WidgetDetail> widgetDetails = widgets.stream().map(widget -> {
@@ -445,11 +447,20 @@ public class DashboardServiceImpl extends BaseService implements DashboardServic
             BeanUtils.copyProperties(widget, widgetDetail);
             widgetDetail.setViewIds(new LinkedList<>());
             widgetDetail.setRelations(new LinkedList<>());
+            widgetIds.add(widgetDetail.getId());
             return widgetDetail;
         }).collect(Collectors.toList());
+
+        if (CollectionUtils.isEmpty(widgetIds)) {
+            return new ArrayList<>(0);
+        }
+        Map<String, List<RelWidgetWidget>> relWidgetWidgetsMap = rwwMapper.listTargetWidgetsByIds(widgetIds).stream().collect(Collectors.groupingBy(RelWidgetWidget::getSourceId));
+        Map<String, List<RelWidgetElement>> elementsMap = rweMapper.listWidgetElementsByIds(widgetIds).stream().collect(Collectors.groupingBy(RelWidgetElement::getWidgetId));
+
+
         for (WidgetDetail widgetDetail : widgetDetails) {
-            widgetDetail.setRelations(rwwMapper.listTargetWidgets(widgetDetail.getId()));
-            List<RelWidgetElement> elements = rweMapper.listWidgetElements(widgetDetail.getId());
+            widgetDetail.setRelations(Optional.ofNullable(relWidgetWidgetsMap.get(widgetDetail.getId())).orElse(new ArrayList<>(0)));
+            List<RelWidgetElement> elements = Optional.ofNullable(elementsMap.get(widgetDetail.getId())).orElse(new ArrayList<>(0));
             for (RelWidgetElement element : elements) {
                 if (ResourceType.DATACHART.name().equals(element.getRelType())) {
                     if (datachartIds != null) {


### PR DESCRIPTION
优化代码，优化获取widget的关联信息，修改为批量从数据获取到关联信息

看原代码获取到widget的关联信息是通过遍历widget，然后每次循环到数据库中获取的关联信息的，这样当要遍历的widget比较多的时候，可能会比较慢

我优化了这部分代码，先在遍历widget信息之前先批量获取从数据库获取到widget的关联信息，然后再在循环中赋值，这样就不用查询多次数据库，提高处理速度