### PR TITLE
 修复资源迁移导入view的时候，没设置parentId为新的问题

### DIFF
--- a/server/src/main/java/datart/server/service/impl/ViewServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/ViewServiceImpl.java
@@ -295,16 +295,6 @@ public class ViewServiceImpl extends BaseService implements ViewService {
         if (model == null || model.getMainModels() == null) {
             return;
         }
-        for (ViewResourceModel.MainModel mainModel : model.getMainModels()) {
-            String newId = UUIDGenerator.generate();
-            viewIdMapping.put(mainModel.getView().getId(), newId);
-            mainModel.getView().setId(newId);
-            mainModel.getView().setSourceId(sourceIdMapping.get(mainModel.getView().getSourceId()));
-            for (Variable variable : mainModel.getVariables()) {
-                variable.setId(UUIDGenerator.generate());
-                variable.setViewId(newId);
-            }
-        }
         Map<String, String> parentIdMapping = new HashMap<>();
         for (View parent : model.getParents()) {
             String newId = UUIDGenerator.generate();
@@ -313,6 +303,17 @@ public class ViewServiceImpl extends BaseService implements ViewService {
         }
         for (View parent : model.getParents()) {
             parent.setParentId(parentIdMapping.get(parent.getParentId()));
+        }
+        for (ViewResourceModel.MainModel mainModel : model.getMainModels()) {
+            String newId = UUIDGenerator.generate();
+            viewIdMapping.put(mainModel.getView().getId(), newId);
+            mainModel.getView().setId(newId);
+            mainModel.getView().setSourceId(sourceIdMapping.get(mainModel.getView().getSourceId()));
+            mainModel.getView().setParentId(parentIdMapping.get(mainModel.getView().getParentId()));
+            for (Variable variable : mainModel.getVariables()) {
+                variable.setId(UUIDGenerator.generate());
+                variable.setViewId(newId);
+            }
         }
     }
 


### PR DESCRIPTION
我在测试资源导入的时候发现，如果view 包含目录导入的时候，view 展示不出来

看了代码发现是导入资源view的时，没重新更新 parentId 导致的，导致view虽然导入进去了，但是因为 parentId  关联不上，所以显示不出来

我这个pr，将导入view的时候，修改为先设置新的目录id，然后再设置view的相关信息，然后重新设置parentId 

麻烦大佬帮忙code view 一下了