### PR TITLE
refactor: update fastjson version fix autoType bug

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.73</version>
+            <version>1.2.83</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
更新 fastjson的版本为1.2.83，之前的版本 有在特定场景下可以绕过autoType关闭限制的漏洞

fastjson 发版说明中有说

https://github.com/alibaba/fastjson/releases/tag/1.2.83