### PR TITLE
fix recommendTimeRangeConverter function case month and year

### DIFF
--- a/frontend/src/app/utils/time.ts
+++ b/frontend/src/app/utils/time.ts
@@ -73,10 +73,10 @@ export function recommendTimeRangeConverter(relativeTimeRange) {
       timeRange = getTimeRange([-90, 0], 'd')('d');
       break;
     case RECOMMEND_TIME.LAST_1_MONTH:
-      timeRange = getTimeRange()('M');
+      timeRange = getTimeRange([-1, 0], 'M')('d');
       break;
     case RECOMMEND_TIME.LAST_1_YEAR:
-      timeRange = getTimeRange()('y');
+      timeRange = getTimeRange([-1, 0], 'y')('d');
       break;
   }
   return timeRange;


### PR DESCRIPTION
recommendTimeRangeConverter方法中，LAST_1_MONTH和LAST_1_YEAR的计算逻辑有问题。比如，LAST_1_MONTH应该是过去一个月，正确的计算结果应该为[上一个月的当时日期，当时日期]，而不是[当月第一天，当月最后一天]。LAST_1_YEAR同理