### PR TITLE
fix: unbind subject before run as other user ； fix download excel or csv

### DIFF
--- a/security/src/main/java/datart/security/manager/shiro/ShiroSecurityManager.java
+++ b/security/src/main/java/datart/security/manager/shiro/ShiroSecurityManager.java
@@ -40,6 +40,7 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Component;
 
@@ -266,6 +267,7 @@ public class ShiroSecurityManager implements DatartSecurityManager {
 
     @Override
     public void runAs(String userNameOrEmail) {
+        ThreadContext.unbindSubject();
         User user = userMapper.selectByNameOrEmail(userNameOrEmail);
         login(JwtUtils.toJwtString(JwtUtils.createJwtToken(user)));
     }


### PR DESCRIPTION
fix: unbind subject before run as other user ； fix download excel or csv

关联这个bug，在runAs之前解绑当前线程的 subject，以免主线程退出后影响该线程数据，导致下载的时候可能出现用户为空，空指针异常，使用 [Drafthj](https://github.com/Drafthj) 的评论方法解决

https://github.com/running-elephant/datart/issues/2018