### PR TITLE
refactor: Compatibility download with null chartColumns

### DIFF
--- a/server/src/main/java/datart/server/common/PoiConvertUtils.java
+++ b/server/src/main/java/datart/server/common/PoiConvertUtils.java
@@ -53,7 +53,7 @@ public class PoiConvertUtils {
         }
         POISettings poiSettings = buildTableHeaderInfo(chartColumns, groupColumns); //构造表头
         poiSettings.setColumnSetting(columnSetting);
-        if (columnSetting.size() != chartColumns.size()) {
+        if (columnSetting.size() != chartColumns.size() || CollectionUtils.isEmpty(chartColumns)) {
             log.warn("column setting parse failed, download with no style.");
             Map<Integer, List<Column>> map = new HashMap<>();
             map.put(0, dataframe.getColumns());


### PR DESCRIPTION
兼容下载excel并且可视化列配置为空的时候，下载到空表头问题


有时候前端会传了一个不存在的datachartId 过来的，这个时候获取到可视化配置就会为空，


对应这里的问题  https://github.com/running-elephant/datart/issues/2018
[HP-jackZhang](https://github.com/HP-jackZhang) commented [issuecomment](https://github.com/running-elephant/datart/issues/2018#issuecomment-1480731387)

至于为什么前端会传了一个不存在的datachartId 过来，是因为目前前端在下载的时候判断可视化组件为widget还是datachart的时候，使用了id是否包含widget来来判断，这种判断在可视化组件为复制的情况下是错误，应该根据 originalType 来判断是widget还是datachart才会更准确