### PR TITLE
refactor: batch get variable from mysql by view Ids

### DIFF
--- a/core/src/main/java/datart/core/mappers/ext/VariableMapperExt.java
+++ b/core/src/main/java/datart/core/mappers/ext/VariableMapperExt.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.*;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @Mapper
 public interface VariableMapperExt extends VariableMapper {
@@ -40,6 +41,14 @@ public interface VariableMapperExt extends VariableMapper {
             "SELECT * FROM variable WHERE view_id = #{viewId} AND `type`='QUERY'"
     })
     List<Variable> selectViewQueryVariables(String viewId);
+
+    @Select({
+            "<script>",
+            "SELECT * FROM variable WHERE  `type`='QUERY' AND view_id in  ",
+            "<foreach collection='viewIds' item='item' index='index' open='(' close=')' separator=','>  #{item} </foreach> ;",
+            "</script>"
+    })
+    List<Variable> selectViewQueryVariablesByViewIds(Set<String> viewIds);
 
     @Select({
             "SELECT * FROM variable WHERE org_id = #{orgId} AND view_id is NULL"

--- a/server/src/main/java/datart/server/service/VariableService.java
+++ b/server/src/main/java/datart/server/service/VariableService.java
@@ -34,6 +34,8 @@ public interface VariableService extends BaseCRUDService<Variable, VariableMappe
 
     List<Variable> listViewQueryVariables(String viewId);
 
+    List<Variable> listViewQueryVariablesByViewIds(Set<String> viewIds);
+
     boolean deleteByIds(Set<String> variableIds);
 
     boolean batchUpdate(List<VariableUpdateParam> updateParams);

--- a/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DashboardServiceImpl.java
@@ -187,9 +187,7 @@ public class DashboardServiceImpl extends BaseService implements DashboardServic
         //variables
         LinkedList<Variable> variables = new LinkedList<>(variableService.listOrgQueryVariables(dashboard.getOrgId()));
         if (!CollectionUtils.isEmpty(viewIds)) {
-            for (String viewId : viewIds) {
-                variables.addAll(variableService.listViewQueryVariables(viewId));
-            }
+            variables.addAll(variableService.listViewQueryVariablesByViewIds(viewIds));
         }
         dashboardDetail.setQueryVariables(variables);
         // download permission

--- a/server/src/main/java/datart/server/service/impl/VariableServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/VariableServiceImpl.java
@@ -135,6 +135,10 @@ public class VariableServiceImpl extends BaseService implements VariableService 
         return variableMapper.selectViewQueryVariables(viewId);
     }
 
+    @Override
+    public List<Variable> listViewQueryVariablesByViewIds(Set<String> viewIds) {
+        return variableMapper.selectViewQueryVariablesByViewIds(viewIds);
+    }
 
     @Override
     @Transactional


### PR DESCRIPTION
 batch get variable from mysql by view Ids

When optimizing the acquisition of dashboard information, traverse the view to obtain variables and modify them to batch retrieve them from the database based on the viewIds set, reducing the need for database queries



优化获取dashboard信息的时候，遍历view 获取变量修改为根据viewIds集合批量去数据库中获取，减少对数据库查询