### PR TITLE
feat(dashboard): Add button component with URL, dashboard, and data chart navigation

### DIFF
--- a/frontend/src/app/components/FormGenerator/Customize/BtnFormat.tsx
+++ b/frontend/src/app/components/FormGenerator/Customize/BtnFormat.tsx
@@ -1,0 +1,212 @@
+import { Input, Radio, Select, Space, Switch, Typography } from 'antd';
+import { FC, memo, useEffect } from 'react';
+import { ChartStyleConfig } from '../../../types/ChartConfig';
+
+import { ItemLayoutProps } from '../types';
+import { updateByKey } from '../../../utils/mutation';
+import { IconList } from '../../../pages/DashBoardPage/components/Widgets/CustomBtnWidget/util/Icon';
+
+const BtnFormat: FC<ItemLayoutProps<ChartStyleConfig>> = memo(
+  ({ ancestors, translate: t = title => title, data, onChange, context }) => {
+    const TextSecondary = props => (
+      <Typography.Text type={'secondary'} {...props} />
+    );
+
+    const handleSettingChange = key => e => {
+      const val = e.target.value;
+      handleSettingChangeWithValue(key)(val);
+    };
+
+    const handleSettingChangeWithValue = key => val => {
+      const newData = updateByKey(
+        data,
+        'value',
+        Object.assign({}, data.value, { [key]: val }),
+      );
+      onChange?.(ancestors, newData);
+    };
+
+    const BtnTypes = [
+      {
+        name: '默认',
+        value: 'default',
+      },
+      {
+        name: '主要',
+        value: 'primary',
+      },
+      {
+        name: '文字',
+        value: 'text',
+      },
+      {
+        name: '链接',
+        value: 'link',
+      },
+      {
+        name: '虚线',
+        value: 'dashed',
+      },
+    ];
+
+    const BtnSizes = [
+      {
+        name: '大',
+        value: 'large',
+      },
+      {
+        name: '中',
+        value: 'middle',
+      },
+      {
+        name: '小',
+        value: 'small',
+      },
+    ];
+
+    return (
+      <Space direction={'vertical'}>
+        <Space direction={'vertical'}>
+          <TextSecondary>按钮文字</TextSecondary>
+          <Input
+            value={data.value?.content}
+            style={{ width: '100%' }}
+            onChange={handleSettingChange('content')}
+            className={'datart-antd-input'}
+          />
+        </Space>
+        <Space direction={'vertical'}>
+          <TextSecondary>按钮类型</TextSecondary>
+          <Select
+            value={data.value?.btnType}
+            style={{ minWidth: '100%' }}
+            onChange={handleSettingChangeWithValue('btnType')}
+          >
+            {BtnTypes.map(ele => (
+              <Select.Option key={ele.value} value={ele.value}>
+                {ele.name}
+              </Select.Option>
+            ))}
+          </Select>
+        </Space>
+        <Space direction={'vertical'}>
+          <TextSecondary>危险操作</TextSecondary>
+          <Switch
+            checked={data.value?.danger}
+            style={{ minWidth: '100%' }}
+            onChange={handleSettingChangeWithValue('danger')}
+          />
+        </Space>
+        <Space direction={'vertical'}>
+          <TextSecondary>按钮图标</TextSecondary>
+          <Select
+            value={data.value?.icon}
+            placeholder={'Ant Design的图标'}
+            style={{ minWidth: 150 }}
+            showSearch={true}
+            onChange={handleSettingChangeWithValue('icon')}
+            options={IconList}
+          />
+        </Space>
+        <Space direction={'vertical'}>
+          <TextSecondary>按钮大小</TextSecondary>
+          <Select
+            value={data.value?.btnSize}
+            style={{ minWidth: '100%' }}
+            onChange={handleSettingChangeWithValue('btnSize')}
+          >
+            {BtnSizes.map(ele => (
+              <Select.Option key={ele.value} value={ele.value}>
+                {ele.name}
+              </Select.Option>
+            ))}
+          </Select>
+        </Space>
+        <Space direction={'vertical'}>
+          <TextSecondary>跳转设置</TextSecondary>
+          <Radio.Group
+            value={data.value?.jumpType}
+            onChange={handleSettingChange('jumpType')}
+          >
+            <Radio.Button value={'url'}>URL</Radio.Button>
+            <Radio.Button value={'dashboard'}>仪表板</Radio.Button>
+            <Radio.Button value={'datachart'}>图表</Radio.Button>
+          </Radio.Group>
+        </Space>
+        {data.value?.jumpType && (
+          <Space direction={'vertical'}>
+            <TextSecondary>打开方式</TextSecondary>
+            <Radio.Group
+              value={data.value?.target}
+              onChange={handleSettingChange('target')}
+            >
+              <Radio.Button value={'_blank'}>新窗口</Radio.Button>
+              <Radio.Button value={'_self'}>当前页</Radio.Button>
+            </Radio.Group>
+          </Space>
+        )}
+        {data.value?.jumpType === 'url' && (
+          <Space direction={'vertical'}>
+            <TextSecondary>URL</TextSecondary>
+            <Input.TextArea
+              value={data.value?.href}
+              style={{ minWidth: '100%' }}
+              onChange={handleSettingChange('href')}
+              className={'datart-antd-input'}
+            />
+          </Space>
+        )}
+        {data.value?.jumpType === 'dashboard' && (
+          <Space direction={'vertical'}>
+            <TextSecondary>仪表板</TextSecondary>
+            <Select
+              virtual
+              showSearch
+              value={data.value?.dashboardId}
+              style={{ minWidth: 100, maxWidth: 200 }}
+              dropdownMatchSelectWidth={false}
+              onChange={handleSettingChangeWithValue('dashboardId')}
+              className={'datart-antd-input'}
+            >
+              {context?.vizs
+                ?.filter(v => v.relType === 'DASHBOARD')
+                ?.map(c => {
+                  return (
+                    <Select.Option key={c.relId} value={c.relId}>
+                      {c.name}
+                    </Select.Option>
+                  );
+                })}
+            </Select>
+          </Space>
+        )}
+        {data.value?.jumpType === 'datachart' && (
+          <Space direction={'vertical'}>
+            <TextSecondary>图表</TextSecondary>
+            <Select
+              virtual
+              showSearch
+              value={data.value?.datachartId}
+              style={{ minWidth: 100, maxWidth: 200 }}
+              dropdownMatchSelectWidth={false}
+              onChange={handleSettingChangeWithValue('datachartId')}
+              className={'datart-antd-input'}
+            >
+              {context?.vizs
+                ?.filter(v => v.relType === 'DATACHART')
+                ?.map(c => {
+                  return (
+                    <Select.Option key={c.relId} value={c.relId}>
+                      {c.name}
+                    </Select.Option>
+                  );
+                })}
+            </Select>
+          </Space>
+        )}
+      </Space>
+    );
+  },
+);
+
+export default BtnFormat;

--- a/frontend/src/app/components/FormGenerator/Customize/index.ts
+++ b/frontend/src/app/components/FormGenerator/Customize/index.ts
@@ -36,3 +36,4 @@ export { default as TimerFormat } from './TimerFormat';
 export { default as UnControlledTableHeaderPanel } from './UnControlledTableHeaderPanel';
 export { default as WidgetBorder } from './WidgetBorder';
 export { default as YAxisNumberFormatPanel } from './YAxisNumberFormatPanel';
+export { default as BtnFormat } from './BtnFormat';

--- a/frontend/src/app/components/FormGenerator/Layout/ItemLayout.tsx
+++ b/frontend/src/app/components/FormGenerator/Layout/ItemLayout.tsx
@@ -69,6 +69,7 @@ import {
   ViewDetailPanel,
   WidgetBorder,
   YAxisNumberFormatPanel,
+  BtnFormat,
 } from '../Customize';
 import { FormGeneratorLayoutProps } from '../types';
 import { groupLayoutComparer, invokeDependencyWatcher } from '../utils';
@@ -216,6 +217,8 @@ const ItemLayout: FC<FormGeneratorLayoutProps<ChartStyleConfig>> = memo(
           return <DataZoomPanel {...props} />;
         case ChartStyleSectionComponentType.Y_AXIS_NUMBER_FORMAT_PANEL:
           return <YAxisNumberFormatPanel {...props} />;
+        case ChartStyleSectionComponentType.BTN_FORMAT:
+          return <BtnFormat {...props} />;
         default:
           return <div>{`no matched component comType of ${data.comType}`}</div>;
       }

--- a/frontend/src/app/constants.ts
+++ b/frontend/src/app/constants.ts
@@ -17,7 +17,7 @@
  */
 
 import { FONT_FAMILY, G90 } from 'styles/StyleConstants';
-import { IFontDefault } from 'types';
+import { ICustomBtnDefault, IFontDefault } from 'types';
 
 export enum TenantManagementMode {
   Team = 'TEAM',
@@ -215,6 +215,7 @@ export const ChartStyleSectionComponentType = {
   TEXT: 'text',
   CONDITIONAL_STYLE: 'conditionalStylePanel',
   RADIO: 'radio',
+  BTN_FORMAT: 'btnFormat',
 
   // Customize Component
   FONT_ALIGNMENT: 'fontAlignment',
@@ -251,6 +252,13 @@ export const FONT_DEFAULT: IFontDefault = {
   fontWeight: 'normal',
   fontStyle: 'normal',
   color: G90,
+};
+
+export const CUSTOM_BTN_DEFAULT: ICustomBtnDefault = {
+  btnSize: 'middle',
+  btnType: 'default',
+  content: '按钮',
+  danger: false,
 };
 
 export enum AuthorizationStatus {

--- a/frontend/src/app/pages/DashBoardPage/components/WidgetManager/index.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/WidgetManager/index.tsx
@@ -39,6 +39,7 @@ import tabProto from '../Widgets/TabWidget/tabConfig';
 import timerProto from '../Widgets/TimerWidget/timerConfig';
 import videoProto from '../Widgets/VideoWidget/videoConfig';
 import { widgetManagerInstance as widgetManager } from './WidgetManager';
+import customBtnProto from '../Widgets/CustomBtnWidget/customBtnConfig';
 
 const protoList: WidgetProto[] = [
   linkedChartProto, // chart
@@ -57,6 +58,7 @@ const protoList: WidgetProto[] = [
   radioGroupProto,
   textProto,
   timeProto,
+  customBtnProto,
   dropDownTree,
   rangeTimeProto,
   rangeValueProto,

--- a/frontend/src/app/pages/DashBoardPage/components/WidgetManager/utils/init.ts
+++ b/frontend/src/app/pages/DashBoardPage/components/WidgetManager/utils/init.ts
@@ -317,7 +317,18 @@ export const TitleI18N = {
     },
   },
 };
-export const initPaddingTpl = () => {
+export const initPaddingTpl = (obj?: {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+}) => {
+  const { top, bottom, left, right } = obj || {
+    top: 8,
+    bottom: 8,
+    left: 8,
+    right: 8,
+  };
   const paddingTpl: ChartStyleConfig = {
     label: 'padding.paddingGroup',
     key: 'paddingGroup',
@@ -326,25 +337,25 @@ export const initPaddingTpl = () => {
       {
         label: 'padding.top',
         key: 'top',
-        value: 8,
+        value: top,
         comType: 'inputNumber',
       },
       {
         label: 'padding.bottom',
         key: 'bottom',
-        value: 8,
+        value: bottom,
         comType: 'inputNumber',
       },
       {
         label: 'padding.left',
         key: 'left',
-        value: 8,
+        value: left,
         comType: 'inputNumber',
       },
       {
         label: 'padding.right',
         key: 'right',
-        value: 8,
+        value: right,
         comType: 'inputNumber',
       },
     ],

--- a/frontend/src/app/pages/DashBoardPage/components/WidgetMapper/WidgetMapper.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/WidgetMapper/WidgetMapper.tsx
@@ -30,6 +30,7 @@ import { RichTextWidget } from '../Widgets/RichTextWidget/RichTextWidget';
 import { TabWidget } from '../Widgets/TabWidget/TabWidget';
 import { TimerWidget } from '../Widgets/TimerWidget/TimerWidget';
 import { VideoWidget } from '../Widgets/VideoWidget/VideoWidget';
+import { CustomBtnWidget } from '../Widgets/CustomBtnWidget/CustomBtnWidget';
 
 export const WidgetMapper: React.FC<{
   boardEditing: boolean;
@@ -63,7 +64,8 @@ export const WidgetMapper: React.FC<{
       return <IframeWidget hideTitle={hideTitle} />;
     case ORIGINAL_TYPE_MAP.timer:
       return <TimerWidget hideTitle={hideTitle} />;
-
+    case ORIGINAL_TYPE_MAP.customBtn:
+      return <CustomBtnWidget hideTitle={hideTitle} />;
     // tab
     case ORIGINAL_TYPE_MAP.tab:
       return <TabWidget hideTitle={hideTitle} />;

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/CustomBtnWidget.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/CustomBtnWidget.tsx
@@ -1,0 +1,60 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Space } from 'antd';
+import { WidgetContext } from 'app/pages/DashBoardPage/components/WidgetProvider/WidgetProvider';
+import { memo, useContext } from 'react';
+import { BoardContext } from '../../BoardProvider/BoardProvider';
+import { FlexStyle, ZIndexStyle } from '../../WidgetComponents/constants';
+import { EditMask } from '../../WidgetComponents/EditMask';
+import { LockIconFn } from '../../WidgetComponents/StatusIcon';
+import { StyledWidgetToolBar } from '../../WidgetComponents/StyledWidgetToolBar';
+import { WidgetDropdownList } from '../../WidgetComponents/WidgetDropdownList';
+import { WidgetWrapper } from '../../WidgetComponents/WidgetWrapper';
+import {
+  getWidgetBaseStyle,
+  getWidgetTitle,
+} from '../../WidgetManager/utils/utils';
+import { CustomBtnWidgetCore } from './CustomBtnWidgetCore';
+
+export const CustomBtnWidget: React.FC<{ hideTitle: boolean }> = memo(
+  ({ hideTitle }) => {
+    const widget = useContext(WidgetContext);
+    const { editing } = useContext(BoardContext);
+    const { background, border, padding } = getWidgetBaseStyle(
+      widget.config.customConfig.props,
+    );
+    const title = getWidgetTitle(widget.config.customConfig.props);
+    title.title = widget.config.name;
+    return (
+      <WidgetWrapper background={background} border={border} padding={padding}>
+        <CustomBtnWidgetCore />
+        {editing && <EditMask />}
+        <StyledWidgetToolBar>
+          <Space size={0}>
+            <LockIconFn
+              boardEditing={editing}
+              wid={widget.id}
+              lock={widget.config?.lock}
+            />
+            <WidgetDropdownList widget={widget} />
+          </Space>
+        </StyledWidgetToolBar>
+      </WidgetWrapper>
+    );
+  },
+);

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/CustomBtnWidgetCore.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/CustomBtnWidgetCore.tsx
@@ -1,0 +1,101 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from 'antd';
+import React, { memo, useContext } from 'react';
+import useDrillThrough from '../../../../../hooks/useDrillThrough';
+import { BoardContext } from '../../BoardProvider/BoardProvider';
+import { WidgetContext } from '../../WidgetProvider/WidgetProvider';
+import { customBtnWidgetToolKit } from './customBtnConfig';
+import { Icon } from './util/Icon';
+
+export const CustomBtnWidgetCore: React.FC = memo(props => {
+  const widget = useContext(WidgetContext);
+  const { orgId } = useContext(BoardContext);
+  const customBtnConfig = customBtnWidgetToolKit.getCustomBtnConfig(
+    widget.config.customConfig.props,
+  );
+  const customBtnFont = customBtnWidgetToolKit.getCustomBtnFont(
+    widget.config.customConfig.props,
+  );
+
+  const btnStyle = {
+    width: '100%',
+    height: '100%',
+    // todo: 适配background style,优先使用button type的预设值
+    // 但下面这样会导致按钮type预设失效
+    // background: 'transparent',
+  };
+
+  // todo: 需要特殊处理font size与 font color,
+  //  令其优先使用button type和button size的预设值
+  const textStyle = {
+    // ...customBtnFont
+  };
+
+  const finalStyle = customBtnFont ? { ...textStyle, ...btnStyle } : btnStyle;
+
+  const { openNewTab, openBrowserTab, redirectByUrl, openNewByUrl } =
+    useDrillThrough();
+
+  const onClick = () => {
+    switch (customBtnConfig?.jumpType) {
+      case 'dashboard':
+        jump(customBtnConfig?.dashboardId);
+        break;
+      case 'datachart':
+        jump(customBtnConfig?.datachartId);
+        break;
+      case 'url':
+        jumpByHref();
+    }
+  };
+
+  const jump = relId => {
+    if (!relId) return;
+    const { target } = customBtnConfig;
+    if (target === '_self') {
+      openNewTab(orgId, relId);
+    } else {
+      openBrowserTab(orgId, relId);
+    }
+  };
+
+  const jumpByHref = () => {
+    const { target, href } = customBtnConfig;
+    if (!href) return;
+    if (target === '_self') {
+      redirectByUrl(href);
+    } else {
+      openNewByUrl(href);
+    }
+  };
+
+  return (
+    <Button
+      style={finalStyle}
+      size={customBtnConfig?.btnSize}
+      type={customBtnConfig?.btnType}
+      danger={customBtnConfig?.danger || false}
+      onClick={onClick}
+      icon={customBtnConfig?.icon && <Icon icon={customBtnConfig.icon} />}
+    >
+      {customBtnConfig?.content}
+    </Button>
+  );
+});

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/customBtnConfig.ts
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/customBtnConfig.ts
@@ -1,0 +1,217 @@
+/**
+ * Datart
+ *
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CUSTOM_BTN_DEFAULT, FONT_DEFAULT } from 'app/constants';
+import {
+  ORIGINAL_TYPE_MAP,
+  TimeDefault,
+} from 'app/pages/DashBoardPage/constants';
+import type {
+  WidgetActionListItem,
+  widgetActionType,
+  WidgetMeta,
+  WidgetProto,
+  WidgetToolkit,
+} from 'app/pages/DashBoardPage/types/widgetTypes';
+import { getJsonConfigs } from 'app/pages/DashBoardPage/utils';
+import { WHITE } from 'styles/StyleConstants';
+import { ICustomBtnDefault, IFontDefault } from '../../../../../../types';
+import { ITimeDefault } from '../../../types/widgetTypes';
+import {
+  initBackgroundTpl,
+  initBorderTpl,
+  initInteractionTpl,
+  initPaddingTpl,
+  initTitleTpl,
+  initWidgetName,
+  InteractionI18N,
+  PaddingI18N,
+  TitleI18N,
+  widgetTpl,
+} from '../../WidgetManager/utils/init';
+
+const initCustomBtnTpl = () => {
+  return [
+    {
+      label: 'customBtn.meta',
+      key: 'metaGroup',
+      comType: 'group',
+      rows: [
+        {
+          label: '按钮属性',
+          key: 'btnFormat',
+          comType: 'btnFormat',
+          value: CUSTOM_BTN_DEFAULT,
+        },
+      ],
+    },
+    {
+      label: 'customBtn.btnFontGroup',
+      key: 'btnFontGroup',
+      comType: 'group',
+      rows: [
+        {
+          label: '按钮字体',
+          key: 'btnFont',
+          comType: 'font',
+          value: FONT_DEFAULT,
+        },
+      ],
+    },
+  ];
+};
+const customBtnI18N = {
+  zh: {
+    meta: '按钮属性',
+    btnFontGroup: '按钮字体',
+  },
+  en: {
+    meta: 'Button Props',
+    btnFontGroup: 'Button Font',
+  },
+};
+const NameI18N = {
+  zh: '按钮',
+  en: 'Button',
+};
+export const widgetMeta: WidgetMeta = {
+  icon: 'query-widget',
+  originalType: ORIGINAL_TYPE_MAP.customBtn,
+  canWrapped: true,
+  controllable: false,
+  linkable: false,
+  canFullScreen: true,
+  singleton: false,
+
+  i18ns: [
+    {
+      lang: 'zh-CN',
+      translation: {
+        ...InteractionI18N.zh,
+        desc: 'customBtn',
+        widgetName: NameI18N.zh,
+        action: {},
+        title: TitleI18N.zh,
+        customBtn: customBtnI18N.zh,
+        background: { backgroundGroup: '背景' },
+        padding: PaddingI18N.zh,
+        border: { borderGroup: '边框' },
+      },
+    },
+    {
+      lang: 'en-US',
+      translation: {
+        ...InteractionI18N.en,
+        desc: 'customBtn',
+        widgetName: NameI18N.en,
+        action: {},
+        title: TitleI18N.en,
+        background: { backgroundGroup: 'Background' },
+        padding: PaddingI18N.en,
+        customBtn: customBtnI18N.en,
+        border: { borderGroup: 'Border' },
+      },
+    },
+  ],
+};
+export interface CustomBtnWidgetToolKit extends WidgetToolkit {
+  getCustomBtnConfig: (props) => ICustomBtnDefault;
+  getCustomBtnFont: (props) => IFontDefault;
+}
+export const widgetToolkit: CustomBtnWidgetToolKit = {
+  create: opt => {
+    const widget = widgetTpl();
+    widget.id = widgetMeta.originalType + widget.id;
+    widget.parentId = opt.parentId || '';
+    widget.viewIds = opt.viewIds || [];
+    widget.relations = opt.relations || [];
+    widget.config.originalType = widgetMeta.originalType;
+    widget.config.type = 'media';
+    widget.config.name = opt.name || '';
+    widget.config.rect.width = 100;
+    widget.config.rect.height = 60;
+    widget.config.pRect.width = 2;
+    widget.config.pRect.height = 1;
+
+    widget.config.customConfig.props = [
+      ...initCustomBtnTpl(),
+      // { ...initTitleTpl() },
+      { ...initBackgroundTpl(WHITE) },
+      { ...initPaddingTpl({ top: 0, bottom: 0, left: 0, right: 0 }) },
+      { ...initBorderTpl() },
+    ];
+
+    widget.config.customConfig.interactions = [...initInteractionTpl()];
+
+    return widget;
+  },
+  getName(key) {
+    return initWidgetName(NameI18N, key);
+  },
+  edit() {},
+  save() {},
+  getDropDownList(...arg) {
+    const list: WidgetActionListItem<widgetActionType>[] = [
+      {
+        key: 'edit',
+        renderMode: ['edit'],
+      },
+      {
+        key: 'delete',
+        renderMode: ['edit'],
+      },
+      {
+        key: 'lock',
+        renderMode: ['edit'],
+      },
+      {
+        key: 'group',
+        renderMode: ['edit'],
+      },
+    ];
+    return list;
+  },
+  getCustomBtnConfig(props) {
+    const [btnFormat] = getJsonConfigs(props, ['metaGroup'], ['btnFormat']) as [
+      ICustomBtnDefault,
+    ];
+    return btnFormat;
+  },
+  getCustomBtnFont(props) {
+    const [btnFont] = getJsonConfigs(props, ['btnFontGroup'], ['btnFont']) as [
+      IFontDefault,
+    ];
+    return btnFont;
+  },
+  // lock() {},
+  // unlock() {},
+  // copy() {},
+  // paste() {},
+  // delete() {},
+  // changeTitle() {},
+  // getMeta() {},
+  // getWidgetName() {},
+  // //
+};
+
+const customBtnProto: WidgetProto = {
+  originalType: widgetMeta.originalType,
+  meta: widgetMeta,
+  toolkit: widgetToolkit,
+};
+export const customBtnWidgetToolKit = widgetToolkit;
+export default customBtnProto;

--- a/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/util/Icon.tsx
+++ b/frontend/src/app/pages/DashBoardPage/components/Widgets/CustomBtnWidget/util/Icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import * as icons from '@ant-design/icons';
+
+export const Icon = (props: { icon: string }) => {
+  const { icon } = props;
+  if (icons[icon] === undefined) return null;
+  const antIcon: { [key: string]: any } = icons;
+  return React.createElement(antIcon[icon]);
+};
+
+export const IconList = Object.keys(icons).map(icon => {
+  return {
+    key: icon,
+    value: icon,
+  };
+});

--- a/frontend/src/app/pages/DashBoardPage/constants.ts
+++ b/frontend/src/app/pages/DashBoardPage/constants.ts
@@ -84,6 +84,7 @@ export const ORIGINAL_TYPE_MAP = {
   timer: 'timer',
   richText: 'richText',
   iframe: 'iframe',
+  customBtn: 'customBtn',
 
   queryBtn: 'queryBtn',
   resetBtn: 'resetBtn',

--- a/frontend/src/app/pages/DashBoardPage/pages/Board/slice/types.ts
+++ b/frontend/src/app/pages/DashBoardPage/pages/Board/slice/types.ts
@@ -335,6 +335,7 @@ export declare const MediaWidgetTypes: [
   'image',
   'video',
   'iframe',
+  'customBtn',
 ];
 
 export type MediaWidgetType = typeof MediaWidgetTypes[number];

--- a/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/BoardToolBar/AddMedia/AddMedia.tsx
+++ b/frontend/src/app/pages/DashBoardPage/pages/BoardEditor/components/BoardToolBar/AddMedia/AddMedia.tsx
@@ -72,6 +72,11 @@ export const AddMedia: React.FC<{}> = () => {
       icon: '',
       type: 'video',
     },
+    {
+      name: '按钮',
+      icon: '',
+      type: 'customBtn',
+    },
   ];
   const mediaWidgetItems = (
     <Menu onClick={onSelectMediaWidget}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -74,3 +74,15 @@ export interface IFontDefault {
   fontStyle: string;
   color: string;
 }
+export interface ICustomBtnDefault {
+  content: string;
+  btnType: 'primary' | 'default' | 'text' | 'dashed' | 'link';
+  btnSize: 'large' | 'middle' | 'small';
+  danger: boolean;
+  icon?: string;
+  jumpType?: 'dashboard' | 'datachart' | 'url';
+  dashboardId?: string;
+  datachartId?: string;
+  href?: string;
+  target?: '_blank' | '_self' | '_parent' | '_top';
+}


### PR DESCRIPTION
This commit adds a new button component to the dashboard. Users can utilize this component to navigate to specific URLs, dashboards, or data charts. Additionally, users have the ability to customize the button styles.

#1799 #1325