### PR TITLE
Resolve  Issue #2282  #2280 Fix Column Permission Issues: Unchecking All Options and Substring Filtering

### DIFF
--- a/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
+++ b/data-providers/data-provider-base/src/main/java/datart/data/provider/ProviderManager.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
@@ -214,7 +215,8 @@ public class ProviderManager extends DataProviderExecuteOptimizer implements Dat
                     .noneMatch(selectColumn ->
                             column.columnKey().equals(selectColumn.getColumnKey())
                                     || column.columnKey().equals(selectColumn.getAlias())
-                                    || column.columnKey().contains(selectColumn.getColumnKey()))) {
+                                    // 用正则做聚合函数权限的判断 剔除原来的contains判断
+                                    ||  Pattern.matches("(\\w+\\(" + selectColumn.getColumnKey() +"\\))",column.columnKey()) ))  {
                 excludeIndex.add(i);
             }
         }

--- a/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
+++ b/server/src/main/java/datart/server/service/impl/DataProviderServiceImpl.java
@@ -406,6 +406,11 @@ public class DataProviderServiceImpl extends BaseService implements DataProvider
         try {
             Set<SelectColumn> columns = new HashSet<>();
             List<RelSubjectColumns> relSubjectColumns = rscMapper.listByUser(view.getId(), getCurrentUser().getId());
+            if(relSubjectColumns.isEmpty()){
+                return Collections.singleton(SelectColumn.of(null, "*"));
+            }else if(relSubjectColumns.size() == 1 && relSubjectColumns.get(0).getColumnPermission().equals("[]")){
+                return Collections.singleton(SelectColumn.of(null, "''"));
+            }
             for (RelSubjectColumns relSubjectColumn : relSubjectColumns) {
                 List<String> cols = (List<String>) objectMapper.readValue(relSubjectColumn.getColumnPermission(), ArrayList.class);
                 if (!CollectionUtils.isEmpty(cols)) {


### PR DESCRIPTION
1. Resolve the issue where unchecking all column permissions allows roles to see all fields.
2. Address the issue where using the 'contains' method for column permissions leads to sub-strings not being filtered out. Switch to using regular expression for a more accurate permission check.

Resolve  Issue
#2282 
#2280 