### PR TITLE
bugfix: 控制器的时间组件获取url变量错误

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -600,7 +600,7 @@ export const getWidgetMap = (
                 ...(content.config.controllerDate as any),
                 startTime: {
                   relativeOrExact: TimeFilterValueCategory.Exact,
-                  exactValue: formatTime(_value as any, TIME_FORMATTER),
+                  exactValue: formatTime(_value?.[0], TIME_FORMATTER),
                 },
               };
               break;


### PR DESCRIPTION
从url传入时间时，控制器的时间组件获取值出错，不能正确显示传入的值。