### PR TITLE
fix: issues/2312, Chart Update event already depends on the isLoading…

### DIFF
--- a/frontend/src/app/components/ChartIFrameContainer/ChartIFrameLifecycleAdapter.tsx
+++ b/frontend/src/app/components/ChartIFrameContainer/ChartIFrameLifecycleAdapter.tsx
@@ -180,7 +180,6 @@ const ChartIFrameLifecycleAdapter: FC<{
     window,
     isShown,
     containerStatus,
-    isLoadingData,
   ]);
 
   /**


### PR DESCRIPTION
Chart Update event already depends on the `isLoadingData` parameter, so there's no need for the resize event to also depend on the `isLoadingData` parameter.  If resize event  also depends on `isLoadingData`,  `onCell` in `ant Table` may be called in resize event, and chartDataSet has be updated, so error happens.