### PR TITLE
Dev fix update sources in修复更新数据源之后，可能另外一个机器上部署的服务没更新 #2355fo

### DIFF
--- a/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/JdbcDataProvider.java
+++ b/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/JdbcDataProvider.java
@@ -143,11 +143,15 @@ public class JdbcDataProvider extends DataProvider {
     private JdbcDataProviderAdapter matchProviderAdapter(DataProviderSource source) {
         JdbcDataProviderAdapter adapter;
         adapter = cachedProviders.get(source.getSourceId());
-        if (adapter != null) {
-            return adapter;
+        JdbcProperties newJdbcProperties = conv2JdbcProperties(source);
+        boolean needCreateNewDataProvider = (adapter == null || !Objects.equals(adapter.getJdbcProperties(), newJdbcProperties));
+        if (needCreateNewDataProvider) {
+            if (adapter != null) {
+                resetSource(source);
+            }
+            adapter = ProviderFactory.createDataProvider(newJdbcProperties, true);
+            cachedProviders.put(source.getSourceId(), adapter);
         }
-        adapter = ProviderFactory.createDataProvider(conv2JdbcProperties(source), true);
-        cachedProviders.put(source.getSourceId(), adapter);
         return adapter;
     }
 


### PR DESCRIPTION
因为datart可能多机器部署，目前接口更新数据源的链接信息是只更新有调用更新数据源接口的那个服务的，在多个服务多机器部署的情况下，可能另外一个服务就没更新了，

所以这里我每次执行sql之前先简单对比目前缓存了的数据源和数据库中的数据源信息是否一样，不一样则更新，这里先处理jdbc的数据源了，因为大部分报表都是jdbc的数据源

`  put /sources`

修复更新数据源之后，可能另外一个机器上部署的服务没更新