### PR TITLE
 change druid datasource breakAfterAcquireFailure default value is false

### DIFF
--- a/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/jdbc/DataSourceFactoryDruidImpl.java
+++ b/data-providers/jdbc-data-provider/src/main/java/datart/data/provider/jdbc/DataSourceFactoryDruidImpl.java
@@ -33,8 +33,8 @@ public class DataSourceFactoryDruidImpl implements DataSourceFactory<DruidDataSo
     public DruidDataSource createDataSource(JdbcProperties jdbcProperties) throws Exception {
         Properties properties = configDataSource(jdbcProperties);
         DruidDataSource druidDataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(properties);
-        druidDataSource.setBreakAfterAcquireFailure(true);
-        druidDataSource.setConnectionErrorRetryAttempts(0);
+        druidDataSource.setBreakAfterAcquireFailure(false);
+        druidDataSource.setConnectionErrorRetryAttempts(3);
         log.info("druid data source created ({})", druidDataSource.getName());
         return druidDataSource;
     }


### PR DESCRIPTION

修改 BreakAfterAcquireFailure 参数为false，以免因为网络原因或者数据库挂了一会，导致链接永远都用不了，如果不修改，有可能数据源因为网络波动原因而一直用不了

 获取连接失败将会引起所有等待获取连接的线程异常,但是数据源仍有效的保留,并在下次调用getConnection()的时候继续尝试获取连接

.如果设为true,那么尝试指定次数后获取连接失败后该数据源将申明已经断开并永久关闭.默认为false


