### PR TITLE
fix:Fix the issue of dashboard jump date parameter transmission

### DIFF
--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -600,7 +600,7 @@ export const getWidgetMap = (
                 ...(content.config.controllerDate as any),
                 startTime: {
                   relativeOrExact: TimeFilterValueCategory.Exact,
-                  exactValue: formatTime(_value as any, TIME_FORMATTER),
+                  exactValue: formatTime(_value[0] as any, TIME_FORMATTER),
                 },
               };
               break;

--- a/frontend/src/app/pages/DashBoardPage/utils/widget.ts
+++ b/frontend/src/app/pages/DashBoardPage/utils/widget.ts
@@ -600,7 +600,7 @@ export const getWidgetMap = (
                 ...(content.config.controllerDate as any),
                 startTime: {
                   relativeOrExact: TimeFilterValueCategory.Exact,
-                  exactValue: formatTime(_value[0] as any, TIME_FORMATTER),
+                  exactValue: formatTime(_value?.[0] as any, TIME_FORMATTER),
                 },
               };
               break;


### PR DESCRIPTION
在一个仪表盘配置跳转，传递参数里有日期时，传递给另外一个仪表盘的日期控制器时不生效
原因是传递的日期是数组直接给了moment转换
![image](https://github.com/user-attachments/assets/8539aadc-a57b-4300-993c-705c92a2e7f9)
![image](https://github.com/user-attachments/assets/77c3f909-0277-46aa-86d7-4d7e23ed192d)
![image](https://github.com/user-attachments/assets/9618cd77-20a4-4727-9d7a-d7a85e184d1e)

